### PR TITLE
Provide cmake option to disable testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ message(STATUS "Setting ${CMAKE_PROJECT_NAME} build type - ${CMAKE_BUILD_TYPE}")
 
 
 #------------------------------------------------------------------------------
+# options
+option(WITH_TESTS "Choose if CUnit tests should be built" TRUE)
+
+
+#------------------------------------------------------------------------------
 # check for headers
 
 include (CheckIncludeFiles)
@@ -95,7 +100,10 @@ include_directories (${ZLIB_INCLUDE_DIR})
 #------------------------------------------------------------------------------
 # cunit and ght
 
-find_package (CUnit)
+if (WITH_TESTS)
+    find_package (CUnit)
+endif (WITH_TESTS)
+
 find_package (LibGHT)
 
 if (LIBGHT_FOUND)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ A PostgreSQL extension for storing point cloud (LIDAR) data.
 - CUnit packages must be installed, or [source built and installed](http://sourceforge.net/projects/cunit/ "CUnit").
 - [Optional] GHT library may be installed for GHT compression support, [built from source](http://github.com/pramsey/libght/ "LibGHT")
 
+Tests can be disabled by passing `WITH_TESTS=FALSE` to cmake, e.g. `cmake .. -DWITH_TESTS=FALSE`.
+This removes the CUnit dependency.
+
 ### Build ###
 
 Run `./configure --help` to get a complete listing of configuration options.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,5 +41,6 @@ if (LIBGHT_FOUND)
   target_link_libraries (libpc-static ght)
 endif (LIBGHT_FOUND)
 
-
-add_subdirectory (cunit)
+if (WITH_TESTS)
+    add_subdirectory (cunit)
+endif (WITH_TESTS)


### PR DESCRIPTION
CUnit does not need to be a dependency for installation and usage, so this patch adds a cmake option (WITH_TESTS) that can be used to disable building of the test suite. WITH_TESTS is set to TRUE by default to keep the default behavior consistent.

This patch also adds a one-liner to the README mentioning the option.
