### PR TITLE
Compile the static library with -fPIC

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,6 +33,7 @@ set_target_properties (libpc-static
     OUTPUT_NAME "pc"
     PREFIX "lib"
     CLEAN_DIRECT_OUTPUT 1
+    COMPILE_FLAGS -fPIC
   )
 
 target_link_libraries (libpc-static xml2)


### PR DESCRIPTION
On Ubuntu precise64, gcc/g++ 4.8, cmake 2.8.11.2, I get a link error between the static libpc and the (default shared) libpointcloud.so. This patch fixes the link error.

Fixes #26