### PR TITLE
Configure cmake files to fix cmake install

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,6 +33,7 @@ set_target_properties (libpc-static
     OUTPUT_NAME "pc"
     PREFIX "lib"
     CLEAN_DIRECT_OUTPUT 1
+    COMPILE_FLAGS -fPIC
   )
 
 target_link_libraries (libpc-static xml2)

--- a/pgsql/CMakeLists.txt
+++ b/pgsql/CMakeLists.txt
@@ -15,6 +15,16 @@ set ( PC_INSTALL_EXENSIONS
   pointcloud.control
   )
 
+configure_file(
+    pointcloud.sql.in
+    ${CMAKE_CURRENT_LIST_DIR}/pointcloud--${POINTCLOUD_VERSION}.sql
+    )
+
+configure_file(
+    pointcloud.control.in
+    ${CMAKE_CURRENT_LIST_DIR}/pointcloud.control
+    )
+
 set(CMAKE_C_FLAGS "${PGSQL_CPPFLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${PGSQL_LDFLAGS}")
 


### PR DESCRIPTION
CMake install is broken w/o this patch. Depends on #55 (which fixes cmake build).