### PR TITLE
Fix PG 9.5 compatibility.

### DIFF
--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -353,15 +353,7 @@ Datum pointcloud_agg_transfn(PG_FUNCTION_ARGS)
 		        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 		         errmsg("could not determine input data type")));
 
-	if (fcinfo->context && IsA(fcinfo->context, AggState))
-	{
-		aggcontext = ((AggState *) fcinfo->context)->aggcontext;
-	}
-	else if (fcinfo->context && IsA(fcinfo->context, WindowAggState))
-	{
-		aggcontext = ((WindowAggState *) fcinfo->context)->aggcontext;
-	}
-	else
+	if ( ! AggCheckCallContext(fcinfo, &aggcontext) )
 	{
 		/* cannot be called directly because of dummy-type argument */
 		elog(ERROR, "pointcloud_agg_transfn called in non-aggregate context");


### PR DESCRIPTION
Replace #88 ( recreated the branch)

Applied this PostGIS patch to pgpointcloud : https://trac.osgeo.org/postgis/changeset/13797/branches/2.0
I do not think we support PG 8.4 for pgpointcloud, hence no test.
Tested against PG9.5 pgdg repositories
Travis is happy with PG 9.3