### PR TITLE
fix crash when a child node is empty in pc schema

### DIFF
--- a/lib/cunit/cu_pc_schema.c
+++ b/lib/cunit/cu_pc_schema.c
@@ -54,6 +54,20 @@ test_schema_from_xml()
 }
 
 static void
+test_schema_from_xml_with_empty_field()
+{
+    PCSCHEMA *myschema = NULL;
+    char *myxmlfile = "data/simple-schema-empty-field.xml";
+    char *xmlstr = file_to_str(myxmlfile);
+    int rv = pc_schema_from_xml(xmlstr, &myschema);
+
+    CU_ASSERT(rv == PC_SUCCESS);
+
+    pc_schema_free(myschema);
+    pcfree(xmlstr);
+}
+
+static void
 test_schema_size()
 {
 	size_t sz = schema->size;
@@ -204,6 +218,7 @@ test_schema_clone(void)
 
 CU_TestInfo schema_tests[] = {
 	PC_TEST(test_schema_from_xml),
+	PC_TEST(test_schema_from_xml_with_empty_field),
 	PC_TEST(test_schema_size),
 	PC_TEST(test_dimension_get),
 	PC_TEST(test_dimension_byteoffsets),

--- a/lib/cunit/data/simple-schema-empty-field.xml
+++ b/lib/cunit/data/simple-schema-empty-field.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pc:PointCloudSchema xmlns:pc="http://pointcloud.org/schemas/PC/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <pc:dimension>
+    <pc:position>1</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description></pc:description>
+    <pc:name>X</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>2</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description>Y coordinate as a long integer. You must use the scale and offset information of the header to determine the double value.</pc:description>
+    <pc:name>Y</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>3</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description>Z coordinate as a long integer. You must use the scale and offset information of the header to determine the double value.</pc:description>
+    <pc:name>Z</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>4</pc:position>
+    <pc:size>2</pc:size>
+    <pc:description>The intensity value is the integer representation of the pulse return magnitude. This value is optional and system specific. However, it should always be included if available.</pc:description>
+    <pc:name>Intensity</pc:name>
+    <pc:interpretation>uint16_t</pc:interpretation>
+    <pc:scale>1</pc:scale>
+  </pc:dimension>
+  <pc:metadata>
+    <Metadata name="compression">dimensional</Metadata>
+    <Metadata name="ght_xmin"></Metadata>
+    <Metadata name="ght_ymin"></Metadata>
+    <Metadata name="ght_xmax"></Metadata>
+    <Metadata name="ght_ymax"></Metadata>
+    <Metadata name="ght_keylength"></Metadata>
+    <Metadata name="ght_depth"></Metadata>
+    <Metadata name="spatialreference" type="id">4326</Metadata>
+  </pc:metadata>
+</pc:PointCloudSchema>

--- a/lib/pc_schema.c
+++ b/lib/pc_schema.c
@@ -458,7 +458,7 @@ pc_schema_from_xml(const char *xml_str, PCSCHEMA **schema)
 				/* These are the values of the dimension */
 				for ( child = cur->children; child; child = child->next )
 				{
-					if( child->type == XML_ELEMENT_NODE )
+					if( child->type == XML_ELEMENT_NODE && child->children != NULL)
 					{
 						char *content = (char*)(child->children->content);
 						char *name = (char*)(child->name);


### PR DESCRIPTION
A segmentation fault occurs and crash postgresql when a child node is empty in a PC schema definition.

This PR tries to fix that. 

Tested only against PostgreSQL 9.5.