### PR TITLE
valgrind-clean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install -q postgresql-server-dev-9.3 libcunit1-dev
+  - sudo apt-get install -q postgresql-server-dev-9.3 libcunit1-dev valgrind
 
 addons:
   postgresql: "9.3" # for "installcheck"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ script:
   - ./configure CFLAGS="-Wall -O2 -g"
   - make
   - make check
+  - valgrind --leak-check=full --error-exitcode=1 --show-leak-kinds=all lib/cunit/cu_tester
   - sudo make install
   - make installcheck || { cat pgsql/regression.diffs && false; }

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ script:
   - ./configure CFLAGS="-Wall -O2 -g"
   - make
   - make check
-  - valgrind --leak-check=full --error-exitcode=1 --show-leak-kinds=all lib/cunit/cu_tester
+  - valgrind --leak-check=full --error-exitcode=1 lib/cunit/cu_tester
   - sudo make install
   - make installcheck || { cat pgsql/regression.diffs && false; }

--- a/lib/cunit/cu_pc_bytes.c
+++ b/lib/cunit/cu_pc_bytes.c
@@ -509,9 +509,9 @@ test_uncompressed_filter()
     CU_ASSERT_EQUAL(fpcb.bytes[0], 'c');
     CU_ASSERT_EQUAL(fpcb.size, 4);
     CU_ASSERT_EQUAL(fpcb.npoints, 4);
-	pc_bytes_free(fpcb);
-    
-//	pc_bytes_free(epcb);
+    pc_bytes_free(fpcb);
+    pc_bitmap_free(map1);
+//    pc_bytes_free(epcb);
 
 }
 

--- a/lib/pc_schema.c
+++ b/lib/pc_schema.c
@@ -402,6 +402,7 @@ pc_schema_from_xml(const char *xml_str, PCSCHEMA **schema)
 	xml_doc = xmlReadMemory(xml_ptr, xml_size, NULL, NULL, 0);
 	if ( ! xml_doc )
 	{
+		xmlCleanupParser();
 		pcwarn("unable to parse schema XML");
 		return PC_FAILURE;
 	}
@@ -416,6 +417,7 @@ pc_schema_from_xml(const char *xml_str, PCSCHEMA **schema)
 	if( ! xpath_ctx )
 	{
 		xmlFreeDoc(xml_doc);
+		xmlCleanupParser();
 		pcwarn("unable to create new XPath context to read schema XML");
 		return PC_FAILURE;
 	}
@@ -430,6 +432,7 @@ pc_schema_from_xml(const char *xml_str, PCSCHEMA **schema)
 	{
 		xmlXPathFreeContext(xpath_ctx);
 		xmlFreeDoc(xml_doc);
+		xmlCleanupParser();
 		pcwarn("unable to evaluate xpath expression \"%s\" against schema XML", xpath_str);
 		return PC_FAILURE;
 	}
@@ -509,6 +512,7 @@ pc_schema_from_xml(const char *xml_str, PCSCHEMA **schema)
 						xmlXPathFreeObject(xpath_obj);
 						xmlXPathFreeContext(xpath_ctx);
 						xmlFreeDoc(xml_doc);
+                		xmlCleanupParser();
 						pc_schema_free(s);
 						pcwarn("schema dimension at position \"%d\" is declared twice", d->position + 1, ndims);
 						return PC_FAILURE;
@@ -528,7 +532,8 @@ pc_schema_from_xml(const char *xml_str, PCSCHEMA **schema)
 					xmlXPathFreeObject(xpath_obj);
 					xmlXPathFreeContext(xpath_ctx);
 					xmlFreeDoc(xml_doc);
-					pc_schema_free(s);
+					xmlCleanupParser();
+            		pc_schema_free(s);
 					pcwarn("schema dimension states position \"%d\", but number of XML dimensions is \"%d\"", d->position + 1, ndims);
 					return PC_FAILURE;
 				}
@@ -549,6 +554,7 @@ pc_schema_from_xml(const char *xml_str, PCSCHEMA **schema)
 	{
 		xmlXPathFreeContext(xpath_ctx);
 		xmlFreeDoc(xml_doc);
+		xmlCleanupParser();
 		pcwarn("unable to evaluate xpath expression \"%s\" against schema XML", xpath_metadata_str);
 		return PC_FAILURE;
 	}
@@ -588,6 +594,7 @@ pc_schema_from_xml(const char *xml_str, PCSCHEMA **schema)
 
 	xmlXPathFreeContext(xpath_ctx);
 	xmlFreeDoc(xml_doc);
+	xmlCleanupParser();
 
 	return PC_SUCCESS;
 }
@@ -651,4 +658,3 @@ pc_schema_get_size(const PCSCHEMA *s)
 {
 	return s->size;
 }
-

--- a/lib/pc_val.c
+++ b/lib/pc_val.c
@@ -125,7 +125,7 @@ pc_double_from_ptr(const uint8_t *ptr, uint32_t interpretation)
     if ( v > max ) { \
       pcwarn("Value %g truncated to "format" to fit in "t, v, max); \
       v = max; \
-    } else if ( val < min ) { \
+    } else if ( v < min ) { \
       pcwarn("Value %g truncated to "format" to fit in "t, v, min); \
       v = min; \
     } \

--- a/lib/pc_val.c
+++ b/lib/pc_val.c
@@ -121,12 +121,12 @@ pc_double_from_ptr(const uint8_t *ptr, uint32_t interpretation)
 	return 0.0;
 }
 
-#define CLAMP(v,min,max,t) do { \
+#define CLAMP(v,min,max,t,format) do { \
     if ( v > max ) { \
-      pcwarn("Value %g truncated to %g to fit in "t, v, max); \
+      pcwarn("Value %g truncated to "format" to fit in "t, v, max); \
       v = max; \
     } else if ( val < min ) { \
-      pcwarn("Value %g truncated to %g to fit in "t, v, min); \
+      pcwarn("Value %g truncated to "format" to fit in "t, v, min); \
       v = min; \
     } \
   } while(0)
@@ -139,7 +139,7 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 	case PC_UINT8:
 	{
 		uint8_t v;
-		CLAMP(val, 0, UINT8_MAX, "uint8_t");
+		CLAMP(val, 0, UINT8_MAX, "uint8_t","%u");
 		v = (uint8_t)lround(val);
 		memcpy(ptr, &(v), sizeof(uint8_t));
 		break;
@@ -147,7 +147,7 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 	case PC_UINT16:
 	{
 		uint16_t v;
-		CLAMP(val, 0, UINT16_MAX, "uint16_t");
+		CLAMP(val, 0, UINT16_MAX, "uint16_t","%u");
 		v = (uint16_t)lround(val);
 		memcpy(ptr, &(v), sizeof(uint16_t));
 		break;
@@ -155,7 +155,7 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 	case PC_UINT32:
 	{
 		uint32_t v;
-		CLAMP(val, 0, UINT32_MAX, "uint32");
+		CLAMP(val, 0, UINT32_MAX, "uint32","%u");
 		v = (uint32_t)lround(val);
 		memcpy(ptr, &(v), sizeof(uint32_t));
 		break;
@@ -163,7 +163,7 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 	case PC_UINT64:
 	{
 		uint64_t v;
-		CLAMP(val, 0, UINT64_MAX, "uint64");
+		CLAMP(val, 0, UINT64_MAX, "uint64","%u");
 		v = (uint64_t)lround(val);
 		memcpy(ptr, &(v), sizeof(uint64_t));
 		break;
@@ -171,7 +171,7 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 	case PC_INT8:
 	{
 		int8_t v;
-		CLAMP(val, INT8_MIN, INT8_MAX, "int8");
+		CLAMP(val, INT8_MIN, INT8_MAX, "int8","%d");
 		v = (int8_t)lround(val);
 		memcpy(ptr, &(v), sizeof(int8_t));
 		break;
@@ -179,7 +179,7 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 	case PC_INT16:
 	{
 		int16_t v;
-		CLAMP(val, INT16_MIN, INT16_MAX, "int16");
+		CLAMP(val, INT16_MIN, INT16_MAX, "int16","%d");
 		v = (int16_t)lround(val);
 		memcpy(ptr, &(v), sizeof(int16_t));
 		break;
@@ -187,7 +187,7 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 	case PC_INT32:
 	{
 		int32_t v;
-		CLAMP(val, INT32_MIN, INT32_MAX, "int32");
+		CLAMP(val, INT32_MIN, INT32_MAX, "int32","%d");
 		v = (int32_t)lround(val);
 		memcpy(ptr, &(v), sizeof(int32_t));
 		break;
@@ -195,7 +195,7 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 	case PC_INT64:
 	{
 		int64_t v;
-		CLAMP(val, INT64_MIN, INT64_MAX, "int64");
+		CLAMP(val, INT64_MIN, INT64_MAX, "int64","%d");
 		v = (int64_t)lround(val);
 		memcpy(ptr, &(v), sizeof(int64_t));
 		break;


### PR DESCRIPTION
steps towards addressing #100 : 
- [x] fix memory leak in test_uncompressed_filter (0826a986a0fcbc812f37c6bdf45fe6aea88c4d1f)
- [x] issuing missing xmlCleanupParser calls (40b2e49d894581dcc4c191a917f97a6c30c031f3)
- [x] Conditional jump or move depends on uninitialised value(s) / Use of uninitialised value of size 4 / Syscall param write(buf) points to uninitialised byte(s) in  `pc_double_to_ptr (pc_val.c:182)` (897d7c086d6dcd931b8d75395a3a3dcec983982b)
- [x] reachable lost block : call_init (dl-init.c:30). This still reachable lost block is not of the concern of pgpointcloud code and may be disregarded -> nothing to do.
