### PR TITLE
PC_Sort and PC_IsSorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,10 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 >      - sigbits -- significant bits removal
 >      - rle -- run-length encoding
 
+**PC_PointN(p pcpatch, n int4)** returns **pcpoint**
+
+> Returns the n-th point of the patch with 1-based indexing. Negative n counts point from the end. 
+
 ## PostGIS Integration ##
 
 The `pointcloud_postgis` extension adds functions that allow you to use PostgreSQL Pointcloud with PostGIS, converting PcPoint and PcPatch to Geometry and doing spatial filtering on point cloud data. The `pointcloud_postgis` extension depends on both the `postgis` and `pointcloud` extensions, so they must be installed first:

--- a/README.md
+++ b/README.md
@@ -451,6 +451,15 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 
 > Returns the n-th point of the patch with 1-based indexing. Negative n counts point from the end. 
 
+**PC_IsSorted(p pcpatch, dimnames text[], strict boolean default true)** returns **boolean**
+
+> Checks whether a pcpatch is sorted lexicographically along the given dimensions. The `strict` option further checks that the ordering is strict (no duplicates).
+
+**PC_Sorted(p pcpatch, dimnames text[])** returns **pcpatch**
+
+> Returns a copy of the input patch lexicographically sorted along the given dimensions.
+
+
 ## PostGIS Integration ##
 
 The `pointcloud_postgis` extension adds functions that allow you to use PostgreSQL Pointcloud with PostGIS, converting PcPoint and PcPatch to Geometry and doing spatial filtering on point cloud data. The `pointcloud_postgis` extension depends on both the `postgis` and `pointcloud` extensions, so they must be installed first:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,6 +13,7 @@ set ( PC_SOURCES
         pc_point.c
         pc_pointlist.c
         pc_schema.c
+        pc_sort.c
         pc_stats.c
         pc_util.c
         pc_val.c
@@ -33,7 +34,7 @@ set_target_properties (libpc-static
     OUTPUT_NAME "pc"
     PREFIX "lib"
     CLEAN_DIRECT_OUTPUT 1
-    COMPILE_FLAGS -fPIC
+    COMPILE_FLAGS "-fPIC -std=gnu89"
   )
 
 target_link_libraries (libpc-static xml2)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -17,6 +17,7 @@ OBJS = \
 	pc_point.o \
 	pc_pointlist.o \
 	pc_schema.o \
+	pc_sort.o \
 	pc_stats.o \
 	pc_util.o \
 	pc_val.o \

--- a/lib/cunit/CMakeLists.txt
+++ b/lib/cunit/CMakeLists.txt
@@ -8,6 +8,7 @@ set (PC_TEST_SOURCES
   cu_pc_bytes.c
   cu_pc_schema.c
   cu_pc_patch.c
+  cu_pc_sort.c
   cu_tester.c
   )
 

--- a/lib/cunit/Makefile
+++ b/lib/cunit/Makefile
@@ -13,7 +13,8 @@ OBJS =	\
 	cu_pc_schema.o \
 	cu_pc_point.o \
 	cu_pc_patch.o \
-	cu_pc_patch_ght.o
+	cu_pc_patch_ght.o \
+	cu_pc_sort.o
 
 ifeq ($(CUNIT_LDFLAGS),)
 # No cunit? Emit message and continue

--- a/lib/cunit/cu_pc_sort.c
+++ b/lib/cunit/cu_pc_sort.c
@@ -1,0 +1,390 @@
+/***********************************************************************
+* cu_pc_sort.c
+*
+*        Testing for the schema API functions
+*
+***********************************************************************/
+
+#include "CUnit/Basic.h"
+#include "cu_tester.h"
+
+/* GLOBALS ************************************************************/
+
+static PCSCHEMA *schema = NULL;
+static const char *xmlfile = "data/simple-schema.xml";
+static const double precision = 0.000001;
+
+// SIMPLE SCHEMA
+// int32_t x
+// int32_t y
+// int32_t z
+// int16_t intensity
+
+/* Setup/teardown for this suite */
+static int
+init_suite(void)
+{
+	char *xmlstr = file_to_str(xmlfile);
+	int rv = pc_schema_from_xml(xmlstr, &schema);
+	pcfree(xmlstr);
+	if ( rv == PC_FAILURE ) return 1;
+	return 0;
+}
+
+static int
+clean_suite(void)
+{
+	pc_schema_free(schema);
+	return 0;
+}
+
+/* TESTS **************************************************************/
+
+static void
+test_sort_simple()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000003000000050006 pt1 (XYZi)
+	// 0000000200000001000000040008 pt2 (XYZi)
+
+    // init data
+    PCPOINTLIST *lisort;
+    PCPATCH *pasort;
+    double d1;
+    double d2;
+	char *hexbuf = "0000000000000000000000000200000008000000030000000500060000000200000001000000040008";
+	size_t hexsize = strlen(hexbuf);
+
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *X[] = {"X"};
+
+    // check that initial data are not sorted
+    pc_point_get_double_by_name(pc_pointlist_get_point(li, 0), "X", &d1);
+    pc_point_get_double_by_name(pc_pointlist_get_point(li, 1), "X", &d2);
+
+	CU_ASSERT_DOUBLE_EQUAL(d1, 0.08, precision);
+	CU_ASSERT_DOUBLE_EQUAL(d2, 0.02, precision);
+
+    // sort on X attribute and check if data are well sorted
+    pasort = pc_patch_sort(pa, X, 1);
+    lisort = pc_pointlist_from_patch(pasort);
+
+    pc_point_get_double_by_name(pc_pointlist_get_point(lisort, 0), "X", &d1);
+    pc_point_get_double_by_name(pc_pointlist_get_point(lisort, 1), "X", &d2);
+
+	CU_ASSERT_DOUBLE_EQUAL(d1, 0.02, precision);
+	CU_ASSERT_DOUBLE_EQUAL(d2, 0.08, precision);
+
+    // free
+    pc_pointlist_free(li);
+    pc_pointlist_free(lisort);
+    pc_patch_free(pa);
+    pc_patch_free(pasort);
+    pcfree(wkb);
+}
+
+static void
+test_sort_consistency()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000003000000050006 pt1 (XYZi)
+	// 0000000200000001000000040008 pt2 (XYZi)
+
+    // init data
+    PCPATCH *pasort;
+    char *pastr, *pasortstr;
+    uint8_t *wkbsort;
+	char *hexbuf = "0000000000000000000000000200000008000000030000000500060000000200000001000000040008";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *X[] = {"X"};
+
+    // sort on X attribute
+    pasort = pc_patch_sort(pa, X, 1);
+
+    //chek consistency
+    wkbsort = pc_patch_to_wkb(pasort, &hexsize);
+    CU_ASSERT_EQUAL(wkb_get_pcid(wkb), wkb_get_pcid(wkbsort));
+    CU_ASSERT_EQUAL(wkb_get_npoints(wkb), wkb_get_npoints(wkbsort));
+    CU_ASSERT_EQUAL(wkb_get_compression(wkb), wkb_get_compression(wkbsort));
+
+    pastr = pc_patch_to_string(pa);
+    CU_ASSERT_STRING_EQUAL(pastr, "{\"pcid\":0,\"pts\":[[0.08,0.03,0.05,6],[0.02,0.01,0.04,8]]}");
+
+    pasortstr = pc_patch_to_string(pasort);
+    CU_ASSERT_STRING_EQUAL(pasortstr, "{\"pcid\":0,\"pts\":[[0.02,0.01,0.04,8],[0.08,0.03,0.05,6]]}");
+
+    // free
+    pcfree(wkb);
+    pcfree(wkbsort);
+    pcfree(pastr);
+    pcfree(pasortstr);
+    pc_patch_free(pasort);
+    pc_patch_free(pa);
+    pc_pointlist_free(li);
+}
+
+static void
+test_sort_one_point()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000001 npoints
+	// 0000000200000003000000050006 pt1 (XYZi)
+
+    // init data
+    PCPATCH *pasort;
+    char *pastr, *pasortstr;
+    uint8_t *wkbsort;
+	char *hexbuf = "000000000000000000000000010000000200000003000000050006";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *X[] = {"X"};
+
+    // sort on X attribute
+    pasort = pc_patch_sort(pa, X, 1);
+
+    // check consistency
+    wkbsort = pc_patch_to_wkb(pasort, &hexsize);
+    CU_ASSERT_EQUAL(wkb_get_pcid(wkb), wkb_get_pcid(wkbsort));
+    CU_ASSERT_EQUAL(wkb_get_npoints(wkb), wkb_get_npoints(wkbsort));
+    CU_ASSERT_EQUAL(wkb_get_compression(wkb), wkb_get_compression(wkbsort));
+
+    pastr = pc_patch_to_string(pa);
+    pasortstr = pc_patch_to_string(pasort);
+    CU_ASSERT_STRING_EQUAL(pastr, pasortstr);
+
+    // free
+    pcfree(wkb);
+    pcfree(wkbsort);
+    pcfree(pastr);
+    pcfree(pasortstr);
+    pc_patch_free(pa);
+    pc_patch_free(pasort);
+    pc_pointlist_free(li);
+}
+
+static void
+test_sort_stable()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000003000000050006 pt1 (XYZi)
+	// 0000000200000003000000040008 pt2 (XYZi)
+	// 0000000200000003000000040009 pt3 (XYZi)
+
+    // init data
+    PCPATCH *pasort;
+	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *dims[] = {"Y"};
+
+    // sort on Y attribute
+    pasort = pc_patch_sort(pa, dims, 1);
+
+    // check that sort is stable
+    char *pastr = pc_patch_to_string(pa);
+    char *pasortstr = pc_patch_to_string(pasort);
+    CU_ASSERT_STRING_EQUAL(pastr, pasortstr);
+
+    // free
+    free(pastr);
+    free(pasortstr);
+    pcfree(wkb);
+    pc_patch_free(pa);
+    pc_patch_free(pasort);
+    pc_pointlist_free(li);
+}
+
+static void
+test_sort_patch_is_sorted_no_compression()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000003000000050006 pt1 (XYZi)
+	// 0000000200000003000000040008 pt2 (XYZi)
+	// 0000000200000003000000040009 pt3 (XYZi)
+
+    // init data
+    PCPATCH *pasort;
+	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *X[] = {"X"};
+
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, X, 1, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, X, 1, PC_TRUE), PC_FALSE);
+
+    pasort = pc_patch_sort(pa, X, 1);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort, X, 1, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort, X, 1, PC_TRUE), PC_TRUE);
+
+    // free
+    pcfree(wkb);
+    pc_patch_free(pa);
+    pc_patch_free(pasort);
+    pc_pointlist_free(li);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional(enum DIMCOMPRESSIONS dimcomp)
+{
+    // init data
+    PCPATCH_DIMENSIONAL *padim1, *padim2, *padimsort;
+    PCPOINT *pt;
+    PCPOINTLIST *pl;
+    int i;
+    int ndims = 1;
+    int npts = PCDIMSTATS_MIN_SAMPLE+1; // force to keep custom compression
+    const char *X[] = {"X"};
+
+    // build a dimensional patch
+    pl = pc_pointlist_make(npts);
+
+    for ( i = npts; i >= 0; i-- )
+    {
+        pt = pc_point_make(schema);
+        pc_point_set_double_by_name(pt, "x", i);
+        pc_point_set_double_by_name(pt, "y", i);
+        pc_point_set_double_by_name(pt, "Z", i);
+        pc_point_set_double_by_name(pt, "intensity", 10);
+        pc_pointlist_add_point(pl, pt);
+    }
+
+    padim1 = pc_patch_dimensional_from_pointlist(pl);
+
+    // set dimensional compression for each dimension
+    PCDIMSTATS *stats = pc_dimstats_make(schema);
+    pc_dimstats_update(stats, padim1);
+    for ( i = 0; i<padim1->schema->ndims; i++ )
+        stats->stats[i].recommended_compression = dimcomp;
+
+    // compress patch
+    padim2 = pc_patch_dimensional_compress(padim1, stats);
+
+    // test that patch is not sorted
+    CU_ASSERT_EQUAL(pc_patch_is_sorted((PCPATCH*) padim2, X, ndims, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted((PCPATCH*) padim2, X, ndims, PC_TRUE), PC_FALSE);
+
+    // sort
+    padimsort = (PCPATCH_DIMENSIONAL*) pc_patch_sort((PCPATCH*) padim2, X, 1);
+
+    // test that resulting data is sorted
+    CU_ASSERT_EQUAL(pc_patch_is_sorted((PCPATCH*) padimsort, X, ndims, PC_TRUE), PC_TRUE);
+
+    // free
+    pc_dimstats_free(stats);
+    pc_patch_free((PCPATCH *)padim1);
+    pc_patch_free((PCPATCH *)padim2);
+    pc_patch_free((PCPATCH *)padimsort);
+    pc_pointlist_free(pl);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional_none()
+{
+    test_sort_patch_is_sorted_compression_dimensional(PC_DIM_NONE);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional_zlib()
+{
+    test_sort_patch_is_sorted_compression_dimensional(PC_DIM_ZLIB);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional_rle()
+{
+    test_sort_patch_is_sorted_compression_dimensional(PC_DIM_RLE);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional_sigbits()
+{
+    test_sort_patch_is_sorted_compression_dimensional(PC_DIM_SIGBITS);
+}
+
+static void
+test_sort_patch_ndims()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000001000000050006 pt1 (XYZi)
+	// 0000000200000003000000040008 pt2 (XYZi)
+	// 0000000200000002000000040008 pt2 (XYZi)
+
+    // init data
+    PCPATCH *pasort1, *pasort2;
+	char *hexbuf = "00000000000000000000000003000000080000000400000005000600000002000000030000000400080000000200000002000000040009";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    const char *X[] = {"X"};
+    const char *Y[] = {"Y"};
+    const char *X_Y[] = {"X", "Y"};
+
+    // test that initial data is not sorted
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, X, 1, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, Y, 1, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, X_Y, 2, PC_FALSE), PC_FALSE);
+
+    // sort on X attribute and test
+    pasort1 = pc_patch_sort(pa, X, 1);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort1, X, 1, PC_TRUE), PC_TRUE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort1, Y, 1, PC_TRUE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort1, X_Y, 2, PC_TRUE), PC_FALSE);
+
+    // sort on X and Y and tst
+    pasort2 = pc_patch_sort(pa, X_Y, 2);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort2, X, 1, PC_TRUE), PC_TRUE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort2, Y, 1, PC_TRUE), PC_TRUE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort2, X_Y, 2, PC_TRUE), PC_TRUE);
+
+    // free
+    pcfree(wkb);
+    pc_patch_free(pasort1);
+    pc_patch_free(pasort2);
+    pc_patch_free(pa);
+}
+
+/* REGISTER ***********************************************************/
+
+CU_TestInfo sort_tests[] = {
+	PC_TEST(test_sort_simple),
+    PC_TEST(test_sort_consistency),
+    PC_TEST(test_sort_one_point),
+    PC_TEST(test_sort_stable),
+    PC_TEST(test_sort_patch_is_sorted_no_compression),
+    PC_TEST(test_sort_patch_is_sorted_compression_dimensional_none),
+    PC_TEST(test_sort_patch_is_sorted_compression_dimensional_zlib),
+    PC_TEST(test_sort_patch_is_sorted_compression_dimensional_sigbits),
+    PC_TEST(test_sort_patch_is_sorted_compression_dimensional_rle),
+    PC_TEST(test_sort_patch_ndims),
+    CU_TEST_INFO_NULL
+};
+
+CU_SuiteInfo sort_suite = {"sort", init_suite, clean_suite, sort_tests};

--- a/lib/cunit/cu_tester.c
+++ b/lib/cunit/cu_tester.c
@@ -18,6 +18,7 @@ extern CU_SuiteInfo patch_suite;
 extern CU_SuiteInfo point_suite;
 extern CU_SuiteInfo ght_suite;
 extern CU_SuiteInfo bytes_suite;
+extern CU_SuiteInfo sort_suite;
 
 /**
  * CUnit error handler
@@ -52,6 +53,7 @@ int main(int argc, char *argv[])
 		point_suite,
 		ght_suite, 
 		bytes_suite, 
+        	sort_suite,
 		CU_SUITE_INFO_NULL
 	};
 

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -424,4 +424,10 @@ PCPATCH* pc_patch_filter_between_by_name(const PCPATCH *pa, const char *name, do
 /** get point n */
 PCPOINT *pc_patch_pointn(const PCPATCH *patch, int n);
 
+/** Sorted patch after reordering points on dimensions */
+PCPATCH *pc_patch_sort(const PCPATCH *pa, const char **name, int ndims);
+
+/** True/false if the patch is sorted on dimension */
+uint32_t pc_patch_is_sorted(const PCPATCH *pa, const char **name, int ndims, char strict);
+
 #endif /* _PC_API_H */

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -421,5 +421,7 @@ PCPATCH* pc_patch_filter_equal_by_name(const PCPATCH *pa, const char *name, doub
 /** Subset batch based on range condition on dimension */
 PCPATCH* pc_patch_filter_between_by_name(const PCPATCH *pa, const char *name, double val1, double val2);
 
+/** get point n */
+PCPOINT *pc_patch_pointn(const PCPATCH *patch, int n);
 
 #endif /* _PC_API_H */

--- a/lib/pc_api_internal.h
+++ b/lib/pc_api_internal.h
@@ -170,6 +170,7 @@ PCPATCH* pc_patch_dimensional_from_wkb(const PCSCHEMA *schema, const uint8_t *wk
 PCPATCH_DIMENSIONAL* pc_patch_dimensional_from_pointlist(const PCPOINTLIST *pdl);
 PCPOINTLIST* pc_pointlist_from_dimensional(const PCPATCH_DIMENSIONAL *pdl);
 PCPATCH_DIMENSIONAL* pc_patch_dimensional_clone(const PCPATCH_DIMENSIONAL *patch);
+PCPOINT *pc_patch_dimensional_pointn(const PCPATCH_DIMENSIONAL *pdl, int n);
 
 /* UNCOMPRESSED PATCHES */
 char* pc_patch_uncompressed_to_string(const PCPATCH_UNCOMPRESSED *patch);
@@ -183,6 +184,7 @@ PCPOINTLIST* pc_pointlist_from_uncompressed(const PCPATCH_UNCOMPRESSED *patch);
 PCPATCH_UNCOMPRESSED* pc_patch_uncompressed_from_pointlist(const PCPOINTLIST *pl);
 PCPATCH_UNCOMPRESSED* pc_patch_uncompressed_from_dimensional(const PCPATCH_DIMENSIONAL *pdl);
 int pc_patch_uncompressed_add_point(PCPATCH_UNCOMPRESSED *c, const PCPOINT *p);
+PCPOINT *pc_patch_uncompressed_pointn(const PCPATCH_UNCOMPRESSED *patch, int n);
 
 /* GHT PATCHES */
 char* pc_patch_ght_to_string(const PCPATCH_GHT *patch);
@@ -195,7 +197,7 @@ uint8_t* pc_patch_ght_to_wkb(const PCPATCH_GHT *patch, size_t *wkbsize);
 PCPATCH* pc_patch_ght_from_wkb(const PCSCHEMA *schema, const uint8_t *wkb, size_t wkbsize);
 PCPOINTLIST* pc_pointlist_from_ght(const PCPATCH_GHT *pag);
 PCPATCH_GHT* pc_patch_ght_filter(const PCPATCH_GHT *patch, uint32_t dimnum, PC_FILTERTYPE filter, double val1, double val2);
-
+PCPOINT *pc_patch_ght_pointn(const PCPATCH_GHT *patch, int n);
 
 /****************************************************************************
 * BYTES
@@ -242,6 +244,13 @@ PCBYTES pc_bytes_filter(const PCBYTES *pcb, const PCBITMAP *map, PCDOUBLESTAT *s
 PCBITMAP* pc_bytes_bitmap(const PCBYTES *pcb, PC_FILTERTYPE filter, double val1, double val2);
 int pc_bytes_minmax(const PCBYTES *pcb, double *min, double *max, double *avg);
 
+/** getting the n-th point out of a PCBYTE into a buffer */
+void pc_bytes_uncompressed_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_run_length_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_sigbits_to_ptr_32(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_sigbits_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_zlib_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
 
 /****************************************************************************
 * BOUNDS

--- a/lib/pc_patch.c
+++ b/lib/pc_patch.c
@@ -432,3 +432,25 @@ pc_patch_from_patchlist(PCPATCH **palist, int numpatches)
 	return (PCPATCH*)paout;
 }
 
+/** get point n from patch */
+/** positive 1-based:  1=first point,  npoints=last  point */
+/** negative 1-based: -1=last  point, -npoints=first point */
+PCPOINT *pc_patch_pointn(const PCPATCH *patch, int n)
+{
+    if(!patch) return NULL;
+    if(n<0) n = patch->npoints+n; // negative indices count a backward
+    else --n; // 1-based => 0-based indexing
+    if(n<0 || n>= patch->npoints) return NULL;
+
+    switch( patch->type )
+    {
+    case PC_NONE:
+        return pc_patch_uncompressed_pointn((PCPATCH_UNCOMPRESSED*)patch,n);
+    case PC_DIMENSIONAL:
+        return pc_patch_dimensional_pointn((PCPATCH_DIMENSIONAL*)patch,n);
+    case PC_GHT:
+        return pc_patch_ght_pointn((PCPATCH_GHT*)patch,n);
+    }
+    pcerror("%s: unsupported compression %d requested", __func__, patch->type);
+    return NULL;
+}

--- a/lib/pc_patch_dimensional.c
+++ b/lib/pc_patch_dimensional.c
@@ -303,3 +303,21 @@ pc_patch_dimensional_from_pointlist(const PCPOINTLIST *pdl)
 	pc_patch_free((PCPATCH*)patch);
 	return dimpatch;
 }
+
+/** get point n, 0-based, positive */
+PCPOINT *pc_patch_dimensional_pointn(const PCPATCH_DIMENSIONAL *pdl, int n)
+{
+    assert(pdl);
+    assert(pdl->schema);
+    int i;
+    int ndims = pdl->schema->ndims;
+    PCPOINT *pt = pc_point_make(pdl->schema);
+    uint8_t *buf = pt->data;
+    for ( i = 0; i < ndims; i++ )
+    {
+        PCDIMENSION *dim = pc_schema_get_dimension(pdl->schema, i);
+        pc_bytes_to_ptr(buf+dim->byteoffset,pdl->bytes[i], n);
+    }
+
+    return pt;
+}

--- a/lib/pc_patch_ght.c
+++ b/lib/pc_patch_ght.c
@@ -609,3 +609,13 @@ pc_pointlist_from_ght(const PCPATCH_GHT *pag)
 	return pc_pointlist_from_uncompressed(pu);
 }
 
+
+PCPOINT *
+pc_patch_ght_pointn(const PCPATCH_GHT *patch, int n)
+{
+	PCPATCH_UNCOMPRESSED *pu;
+	pu = pc_patch_uncompressed_from_ght(patch);
+	PCPOINT *pt = pc_patch_uncompressed_pointn(pu,n);
+	pc_patch_free((PCPATCH *)pu);
+	return pt;
+}

--- a/lib/pc_patch_uncompressed.c
+++ b/lib/pc_patch_uncompressed.c
@@ -419,3 +419,8 @@ pc_patch_uncompressed_add_point(PCPATCH_UNCOMPRESSED *c, const PCPOINT *p)
 	return PC_SUCCESS;
 }
 
+/** get point n, 0-based, positive */
+PCPOINT *pc_patch_uncompressed_pointn(const PCPATCH_UNCOMPRESSED *patch, int n)
+{
+	return pc_point_from_data(patch->schema, patch->data+n*patch->schema->size);
+}

--- a/lib/pc_sort.c
+++ b/lib/pc_sort.c
@@ -1,0 +1,267 @@
+/***********************************************************************
+* pc_sort.c
+*
+*  Pointclound patch sorting.
+*
+*  Copyright (c) 2016 IGN
+*
+*  Author: M. Brédif
+*
+***********************************************************************/
+#include "pc_api_internal.h"
+#include <assert.h>
+#include <stdlib.h>
+
+// NULL terminated array of PCDIMENSION pointers
+typedef PCDIMENSION ** PCDIMENSION_LIST;
+
+/**
+ * Comparators
+ */
+
+int
+pc_compare_dim (const void *a, const void *b, void *arg)
+{
+    PCDIMENSION_LIST dim = (PCDIMENSION_LIST)arg;
+    uint32_t byteoffset     = dim[0]->byteoffset;
+    uint32_t interpretation = dim[0]->interpretation;
+    double da = pc_double_from_ptr(a+byteoffset,interpretation);
+    double db = pc_double_from_ptr(b+byteoffset,interpretation);
+    int cmp = ((da > db) - (da < db));
+    return ( cmp == 0 && dim[1]) ? pc_compare_dim(a,b,dim+1) : cmp;
+}
+
+int
+pc_compare_pcb (const void *a, const void *b, const void *arg)
+{
+    PCBYTES *pcb = (PCBYTES *)arg;
+    double da = pc_double_from_ptr(a,pcb->interpretation);
+    double db = pc_double_from_ptr(b,pcb->interpretation);
+    return ((da > db) - (da < db));
+}
+
+
+/**
+ * Sort
+ */
+
+PCPATCH_UNCOMPRESSED *
+pc_patch_uncompressed_sort(const PCPATCH_UNCOMPRESSED *pu, PCDIMENSION_LIST dim)
+{
+    PCPATCH_UNCOMPRESSED *spu = pc_patch_uncompressed_make(pu->schema, pu->npoints);
+    
+    memcpy(spu->data, pu->data, pu->datasize);
+    spu->npoints = pu->npoints;
+    spu->bounds  = pu->bounds;
+    spu->stats   = pc_stats_clone(pu->stats);
+    
+    qsort_r(spu->data, spu->npoints, pu->schema->size, pc_compare_dim, dim);
+    
+    return spu;
+}
+
+PCDIMENSION_LIST pc_schema_get_dimensions_by_name(const PCSCHEMA *schema, const char ** name, int ndims)
+{
+    PCDIMENSION_LIST dim = pcalloc( (ndims+1) * sizeof(PCDIMENSION *));
+    int i;
+    for(i=0; i<ndims; ++i) 
+    {
+        dim[i] = pc_schema_get_dimension_by_name(schema, name[i]);
+        if ( ! dim[i] ) {
+            pcerror("dimension \"%s\" does not exist", name[i]);
+            return NULL;
+        }
+        assert(dim[i]->scale>0);
+    }
+    dim[ndims] = NULL;
+    return dim;
+}
+
+PCPATCH *
+pc_patch_sort(const PCPATCH *pa, const char ** name, int ndims)
+{
+    PCDIMENSION_LIST dim = pc_schema_get_dimensions_by_name(pa->schema, name, ndims);
+    PCPATCH *pu = pc_patch_uncompress(pa);
+    if ( !pu ) {
+        pcfree(dim);
+        pcerror("Patch uncompression failed");
+        return NULL;
+    }
+    PCPATCH *ps = (PCPATCH *)pc_patch_uncompressed_sort((PCPATCH_UNCOMPRESSED *)pu, dim);
+    
+    pcfree(dim);
+    if ( pu != pa )
+        pc_patch_free(pu);
+    return ps;
+}
+
+
+/**
+ * IsSorted
+ */
+
+uint32_t
+pc_patch_uncompressed_is_sorted(const PCPATCH_UNCOMPRESSED *pu, PCDIMENSION_LIST dim, char strict)
+{
+    size_t size = pu->schema->size;
+    uint8_t *buf = pu->data, *last = pu->data+pu->datasize-size;
+    while ( buf < last )
+    {
+        if( pc_compare_dim(buf,buf+size,dim) >= strict )
+            return PC_FALSE;
+        buf += size;
+    }
+    return PC_TRUE;
+}
+
+uint32_t
+pc_bytes_uncompressed_is_sorted(const PCBYTES *pcb, char strict)
+{
+    assert(pcb->compression == PC_DIM_NONE);
+    size_t size = pc_interpretation_size(pcb->interpretation);
+    uint8_t *buf  = pcb->bytes;
+    uint8_t *last = buf+pcb->size-size;
+    while ( buf < last )
+    {
+        if( pc_compare_pcb(buf,buf+size,pcb) >= strict )
+            return PC_FALSE;
+        buf += size;
+    }
+    return PC_TRUE;
+}
+
+
+uint32_t
+pc_bytes_sigbits_is_sorted(const PCBYTES *pcb, char strict)
+{
+    assert(pcb->compression == PC_DIM_SIGBITS);
+    pcinfo("%s not implemented, decoding",__func__);
+    PCBYTES dpcb = pc_bytes_decode(*pcb);
+    uint32_t is_sorted = pc_bytes_uncompressed_is_sorted(&dpcb,strict);
+    pc_bytes_free(dpcb);
+    return is_sorted;
+}
+
+uint32_t
+pc_bytes_zlib_is_sorted(const PCBYTES *pcb, char strict)
+{
+    assert(pcb->compression == PC_DIM_ZLIB);
+    pcinfo("%s not implemented, decoding",__func__);
+    PCBYTES dpcb = pc_bytes_decode(*pcb);
+    uint32_t is_sorted = pc_bytes_uncompressed_is_sorted(&dpcb,strict);
+    pc_bytes_free(dpcb);
+    return is_sorted;
+}
+
+
+uint32_t
+pc_bytes_run_length_is_sorted(const PCBYTES *pcb, char strict)
+{
+    assert(pcb->compression == PC_DIM_RLE);
+    uint8_t run;
+    size_t size = pc_interpretation_size(pcb->interpretation);
+    const uint8_t *bytes_rle_curr_val = pcb->bytes + 1;
+    const uint8_t *bytes_rle_next_val = pcb->bytes + 2 + size;
+    const uint8_t *bytes_rle_end_val  = pcb->bytes + pcb->size - size;
+    while( bytes_rle_next_val < bytes_rle_end_val )
+    {
+        run = bytes_rle_curr_val[-1];
+        assert(run>0);
+        if( pc_compare_pcb(bytes_rle_curr_val,bytes_rle_next_val,pcb) >= strict // value comparison
+                || (strict && run > 1) ) // run_length should be 1 if strict
+            return PC_FALSE;
+        bytes_rle_curr_val = bytes_rle_next_val;
+        bytes_rle_next_val += 1 + size;
+    }
+    return PC_TRUE;
+}
+
+
+uint32_t
+pc_patch_dimensional_is_sorted(const PCPATCH_DIMENSIONAL *pdl, PCDIMENSION_LIST dim, char strict)
+{
+    assert(pdl);
+    assert(pdl->schema);
+
+    // uncompress when checking multiple dimensions
+    if(dim[1])
+    {
+        PCPATCH *pu = pc_patch_uncompress((PCPATCH*) pdl);
+        if ( !pu ) {
+            pcerror("Patch uncompression failed");
+            return PC_FAILURE - 1; // aliasing issue : PC_FALSE == PC_FAILURE...
+        }
+        uint32_t res = pc_patch_uncompressed_is_sorted((PCPATCH_UNCOMPRESSED *)pu,dim,strict);
+        pc_patch_free(pu);
+        return res;
+    }
+
+    PCBYTES *pcb = pdl->bytes + dim[0]->position;
+    switch ( pcb->compression )
+    {
+    case PC_DIM_RLE:
+    {
+        return pc_bytes_run_length_is_sorted(pcb,strict);
+    }
+    case PC_DIM_SIGBITS:
+    {
+        return pc_bytes_sigbits_is_sorted(pcb,strict);
+    }
+    case PC_DIM_ZLIB:
+    {
+        return pc_bytes_zlib_is_sorted(pcb,strict);
+    }
+    case PC_DIM_NONE:
+    {
+        return pc_bytes_uncompressed_is_sorted(pcb,strict);
+    }
+    default:
+    {
+        pcerror("%s: Uh oh", __func__);
+    }
+    }
+    return PC_FAILURE;
+}
+
+
+uint32_t
+pc_patch_ght_is_sorted(const PCPATCH_GHT *pa, PCDIMENSION_LIST dim, char strict)
+{
+    PCPATCH *pu = pc_patch_uncompress((PCPATCH*) pa);
+    if ( !pu ) {
+        pcerror("Patch uncompression failed");
+        return PC_FAILURE - 1; // aliasing issue : PC_FALSE == PC_FAILURE...
+    }
+    uint32_t res = pc_patch_uncompressed_is_sorted((PCPATCH_UNCOMPRESSED *)pu,dim,strict);
+    pc_patch_free(pu);
+    return res;
+}
+
+
+uint32_t
+pc_patch_is_sorted(const PCPATCH *pa, const char **name, int ndims, char strict)
+{
+    int res = PC_FAILURE -1; // aliasing issue : PC_FALSE == PC_FAILURE...
+    PCDIMENSION_LIST dim = pc_schema_get_dimensions_by_name(pa->schema, name, ndims);
+    if ( ! dim ) return res;
+    strict = (strict > 0); // ensure 0-1 value
+
+    switch( pa->type )
+    {
+    case PC_NONE:
+        res = pc_patch_uncompressed_is_sorted((PCPATCH_UNCOMPRESSED*)pa,dim,strict); 
+        break;
+    case PC_DIMENSIONAL:
+        res = pc_patch_dimensional_is_sorted((PCPATCH_DIMENSIONAL*)pa,dim,strict);
+        break;
+    case PC_GHT:
+        res = pc_patch_ght_is_sorted((PCPATCH_GHT*)pa,dim,strict);
+        break;
+    default:
+        pcerror("%s: unsupported compression %d requested", __func__, pa->type);
+    }
+    pcfree(dim);
+    return res;
+}
+
+

--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -23,6 +23,7 @@ Datum pcpatch_from_pcpatch_array(PG_FUNCTION_ARGS);
 Datum pcpatch_uncompress(PG_FUNCTION_ARGS);
 Datum pcpatch_compress(PG_FUNCTION_ARGS);
 Datum pcpatch_numpoints(PG_FUNCTION_ARGS);
+Datum pcpatch_pointn(PG_FUNCTION_ARGS);
 Datum pcpatch_pcid(PG_FUNCTION_ARGS);
 Datum pcpatch_summary(PG_FUNCTION_ARGS);
 Datum pcpatch_compression(PG_FUNCTION_ARGS);
@@ -645,6 +646,25 @@ Datum pcpatch_numpoints(PG_FUNCTION_ARGS)
 {
 	SERIALIZED_PATCH *serpa = PG_GETHEADER_SERPATCH_P(0);
 	PG_RETURN_INT32(serpa->npoints);
+}
+
+PG_FUNCTION_INFO_V1(pcpatch_pointn);
+Datum pcpatch_pointn(PG_FUNCTION_ARGS)
+{
+	SERIALIZED_POINT *serpt;
+	SERIALIZED_PATCH *serpa = PG_GETARG_SERPATCH_P(0);
+	int32 n = PG_GETARG_INT32(1);
+	PCSCHEMA *schema = pc_schema_from_pcid(serpa->pcid, fcinfo);
+	PCPATCH *patch = pc_patch_deserialize(serpa, schema);
+	PCPOINT *pt = NULL;
+	if(patch) {
+		pt = pc_patch_pointn(patch,n);
+		pc_patch_free(patch);
+	}
+	if(!pt) PG_RETURN_NULL();
+	serpt = pc_point_serialize(pt);
+	pc_point_free(pt);
+	PG_RETURN_POINTER(serpt);
 }
 
 PG_FUNCTION_INFO_V1(pcpatch_pcid);

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -297,6 +297,10 @@ CREATE OR REPLACE FUNCTION PC_FilterBetween(p pcpatch, attr text, v1 float8 defa
 	RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_filter'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_PointN(p pcpatch, n int4)
+    RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpatch_pointn'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -301,6 +301,14 @@ CREATE OR REPLACE FUNCTION PC_PointN(p pcpatch, n int4)
     RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpatch_pointn'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_Sort(p pcpatch, attr text[])
+        RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_sort'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+      
+CREATE OR REPLACE FUNCTION PC_IsSorted(p pcpatch, attr text[], strict boolean default false)
+        RETURNS boolean AS 'MODULE_PATHNAME', 'pcpatch_is_sorted'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------


### PR DESCRIPTION
This pull request proposes 2 new interrelated functions:
- `PC_Sort( pcpatch, text[] ) : pcpatch`
- `PC_IsSorted( pcpatch, text[], boolean ) : boolean`


#### `PC_Sort( pa pcpatch, attr text[] ) : pcpatch`

(pgpointcloud/pointcloud#54, LI3DS/pointcloud#10) 

Lexicographically sort a patch `pa` on the given dimensions `attr`.

What is natively implemented ?
- [x]  Uncompressed
- [x]  Other compressions fall back to uncompression
- [ ]  Dimensional Uncompressed
- [ ]  Dimensional SigBits
- [ ]  Dimensional Zlib
- [ ]  Dimensional RLE
- [ ]  GHT

#### `PC_IsSorted( pa pcpatch, attr text[], strict boolean default false ) : boolean`

(LI3DS/pointcloud#9)

Test whether a patch `pa` is lexicographically sorted on the given dimensions `attr`.
The `strict` option requires strict sorting (no duplicates).

What is natively implemented ?
- [x]  Uncompressed
- [x]  Other compressions fall back to uncompression
- [x]  Dimensional Uncompressed (single dimension)
- [ ]  Dimensional SigBits (single dimension)
- [ ]  Dimensional Zlib (single dimension)
- [x]  Dimensional RLE (single dimension)
- [ ]  Dimensional Uncompressed
- [ ]  Dimensional SigBits
- [ ]  Dimensional Zlib
- [ ]  Dimensional RLE
- [ ]  GHT

#### Contributors
- functionalities : @mbredif
- tests : @pblottiere