### PR TITLE
new PC_PointN function

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,10 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 >      - sigbits -- significant bits removal
 >      - rle -- run-length encoding
 
+**PC_PointN(p pcpatch, n int4)** returns **pcpoint**
+
+> Returns the n-th point of the patch with 1-based indexing. Negative n counts point from the end. 
+
 ## PostGIS Integration ##
 
 The `pointcloud_postgis` extension adds functions that allow you to use PostgreSQL Pointcloud with PostGIS, converting PcPoint and PcPatch to Geometry and doing spatial filtering on point cloud data. The `pointcloud_postgis` extension depends on both the `postgis` and `pointcloud` extensions, so they must be installed first:

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -421,5 +421,7 @@ PCPATCH* pc_patch_filter_equal_by_name(const PCPATCH *pa, const char *name, doub
 /** Subset batch based on range condition on dimension */
 PCPATCH* pc_patch_filter_between_by_name(const PCPATCH *pa, const char *name, double val1, double val2);
 
+/** get point n */
+PCPOINT *pc_patch_pointn(const PCPATCH *patch, int n);
 
 #endif /* _PC_API_H */

--- a/lib/pc_api_internal.h
+++ b/lib/pc_api_internal.h
@@ -170,6 +170,7 @@ PCPATCH* pc_patch_dimensional_from_wkb(const PCSCHEMA *schema, const uint8_t *wk
 PCPATCH_DIMENSIONAL* pc_patch_dimensional_from_pointlist(const PCPOINTLIST *pdl);
 PCPOINTLIST* pc_pointlist_from_dimensional(const PCPATCH_DIMENSIONAL *pdl);
 PCPATCH_DIMENSIONAL* pc_patch_dimensional_clone(const PCPATCH_DIMENSIONAL *patch);
+PCPOINT *pc_patch_dimensional_pointn(const PCPATCH_DIMENSIONAL *pdl, int n);
 
 /* UNCOMPRESSED PATCHES */
 char* pc_patch_uncompressed_to_string(const PCPATCH_UNCOMPRESSED *patch);
@@ -183,6 +184,7 @@ PCPOINTLIST* pc_pointlist_from_uncompressed(const PCPATCH_UNCOMPRESSED *patch);
 PCPATCH_UNCOMPRESSED* pc_patch_uncompressed_from_pointlist(const PCPOINTLIST *pl);
 PCPATCH_UNCOMPRESSED* pc_patch_uncompressed_from_dimensional(const PCPATCH_DIMENSIONAL *pdl);
 int pc_patch_uncompressed_add_point(PCPATCH_UNCOMPRESSED *c, const PCPOINT *p);
+PCPOINT *pc_patch_uncompressed_pointn(const PCPATCH_UNCOMPRESSED *patch, int n);
 
 /* GHT PATCHES */
 char* pc_patch_ght_to_string(const PCPATCH_GHT *patch);
@@ -195,7 +197,7 @@ uint8_t* pc_patch_ght_to_wkb(const PCPATCH_GHT *patch, size_t *wkbsize);
 PCPATCH* pc_patch_ght_from_wkb(const PCSCHEMA *schema, const uint8_t *wkb, size_t wkbsize);
 PCPOINTLIST* pc_pointlist_from_ght(const PCPATCH_GHT *pag);
 PCPATCH_GHT* pc_patch_ght_filter(const PCPATCH_GHT *patch, uint32_t dimnum, PC_FILTERTYPE filter, double val1, double val2);
-
+PCPOINT *pc_patch_ght_pointn(const PCPATCH_GHT *patch, int n);
 
 /****************************************************************************
 * BYTES
@@ -242,6 +244,13 @@ PCBYTES pc_bytes_filter(const PCBYTES *pcb, const PCBITMAP *map, PCDOUBLESTAT *s
 PCBITMAP* pc_bytes_bitmap(const PCBYTES *pcb, PC_FILTERTYPE filter, double val1, double val2);
 int pc_bytes_minmax(const PCBYTES *pcb, double *min, double *max, double *avg);
 
+/** getting the n-th point out of a PCBYTE into a buffer */
+void pc_bytes_uncompressed_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_run_length_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_sigbits_to_ptr_32(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_sigbits_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_zlib_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
+void pc_bytes_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
 
 /****************************************************************************
 * BOUNDS

--- a/lib/pc_patch.c
+++ b/lib/pc_patch.c
@@ -432,3 +432,25 @@ pc_patch_from_patchlist(PCPATCH **palist, int numpatches)
 	return (PCPATCH*)paout;
 }
 
+/** get point n from patch */
+/** positive 1-based:  1=first point,  npoints=last  point */
+/** negative 1-based: -1=last  point, -npoints=first point */
+PCPOINT *pc_patch_pointn(const PCPATCH *patch, int n)
+{
+    if(!patch) return NULL;
+    if(n<0) n = patch->npoints+n; // negative indices count a backward
+    else --n; // 1-based => 0-based indexing
+    if(n<0 || n>= patch->npoints) return NULL;
+
+    switch( patch->type )
+    {
+    case PC_NONE:
+        return pc_patch_uncompressed_pointn((PCPATCH_UNCOMPRESSED*)patch,n);
+    case PC_DIMENSIONAL:
+        return pc_patch_dimensional_pointn((PCPATCH_DIMENSIONAL*)patch,n);
+    case PC_GHT:
+        return pc_patch_ght_pointn((PCPATCH_GHT*)patch,n);
+    }
+    pcerror("%s: unsupported compression %d requested", __func__, patch->type);
+    return NULL;
+}

--- a/lib/pc_patch_dimensional.c
+++ b/lib/pc_patch_dimensional.c
@@ -303,3 +303,21 @@ pc_patch_dimensional_from_pointlist(const PCPOINTLIST *pdl)
 	pc_patch_free((PCPATCH*)patch);
 	return dimpatch;
 }
+
+/** get point n, 0-based, positive */
+PCPOINT *pc_patch_dimensional_pointn(const PCPATCH_DIMENSIONAL *pdl, int n)
+{
+    assert(pdl);
+    assert(pdl->schema);
+    int i;
+    int ndims = pdl->schema->ndims;
+    PCPOINT *pt = pc_point_make(pdl->schema);
+    uint8_t *buf = pt->data;
+    for ( i = 0; i < ndims; i++ )
+    {
+        PCDIMENSION *dim = pc_schema_get_dimension(pdl->schema, i);
+        pc_bytes_to_ptr(buf+dim->byteoffset,pdl->bytes[i], n);
+    }
+
+    return pt;
+}

--- a/lib/pc_patch_ght.c
+++ b/lib/pc_patch_ght.c
@@ -609,3 +609,13 @@ pc_pointlist_from_ght(const PCPATCH_GHT *pag)
 	return pc_pointlist_from_uncompressed(pu);
 }
 
+
+PCPOINT *
+pc_patch_ght_pointn(const PCPATCH_GHT *patch, int n)
+{
+	PCPATCH_UNCOMPRESSED *pu;
+	pu = pc_patch_uncompressed_from_ght(patch);
+	PCPOINT *pt = pc_patch_uncompressed_pointn(pu,n);
+	pc_patch_free((PCPATCH *)pu);
+	return pt;
+}

--- a/lib/pc_patch_uncompressed.c
+++ b/lib/pc_patch_uncompressed.c
@@ -419,3 +419,8 @@ pc_patch_uncompressed_add_point(PCPATCH_UNCOMPRESSED *c, const PCPOINT *p)
 	return PC_SUCCESS;
 }
 
+/** get point n, 0-based, positive */
+PCPOINT *pc_patch_uncompressed_pointn(const PCPATCH_UNCOMPRESSED *patch, int n)
+{
+	return pc_point_from_data(patch->schema, patch->data+n*patch->schema->size);
+}

--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -23,6 +23,7 @@ Datum pcpatch_from_pcpatch_array(PG_FUNCTION_ARGS);
 Datum pcpatch_uncompress(PG_FUNCTION_ARGS);
 Datum pcpatch_compress(PG_FUNCTION_ARGS);
 Datum pcpatch_numpoints(PG_FUNCTION_ARGS);
+Datum pcpatch_pointn(PG_FUNCTION_ARGS);
 Datum pcpatch_pcid(PG_FUNCTION_ARGS);
 Datum pcpatch_summary(PG_FUNCTION_ARGS);
 Datum pcpatch_compression(PG_FUNCTION_ARGS);
@@ -645,6 +646,25 @@ Datum pcpatch_numpoints(PG_FUNCTION_ARGS)
 {
 	SERIALIZED_PATCH *serpa = PG_GETHEADER_SERPATCH_P(0);
 	PG_RETURN_INT32(serpa->npoints);
+}
+
+PG_FUNCTION_INFO_V1(pcpatch_pointn);
+Datum pcpatch_pointn(PG_FUNCTION_ARGS)
+{
+	SERIALIZED_POINT *serpt;
+	SERIALIZED_PATCH *serpa = PG_GETARG_SERPATCH_P(0);
+	int32 n = PG_GETARG_INT32(1);
+	PCSCHEMA *schema = pc_schema_from_pcid(serpa->pcid, fcinfo);
+	PCPATCH *patch = pc_patch_deserialize(serpa, schema);
+	PCPOINT *pt = NULL;
+	if(patch) {
+		pt = pc_patch_pointn(patch,n);
+		pc_patch_free(patch);
+	}
+	if(!pt) PG_RETURN_NULL();
+	serpt = pc_point_serialize(pt);
+	pc_point_free(pt);
+	PG_RETURN_POINTER(serpt);
 }
 
 PG_FUNCTION_INFO_V1(pcpatch_pcid);

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -297,6 +297,10 @@ CREATE OR REPLACE FUNCTION PC_FilterBetween(p pcpatch, attr text, v1 float8 defa
 	RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_filter'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_PointN(p pcpatch, n int4)
+    RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpatch_pointn'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a PostgreSQL pointcloud equivalent of [ST_PointN](http://postgis.net/docs/ST_PointN.html)

        PC_PointN(patch pcpatch, n int4) : pcpoint

get point `n`-th from patch (LI3DS/pointcloud#14)

- [x] `n` is 1-based, and negative indices count from the end.
 - first point : `1` or `-PC_NumPoints(patch)`
 - last point : `-1` or `PC_NumPoints(patch)`
- [ ] DETOAST only what is strictly necessary (rather than the whole patch)

Native implementations other compressions relying on uncompression :
- [x]  Uncompressed
- [x]  Dimensional Uncompressed
- [x]  Dimensional SigBits
- [ ]  Dimensional Zlib
- [x]  Dimensional RLE
- [ ]  GHT


#### Contributors
- functionalities : @mbredif
- tests : @pblottiere

