### PR TITLE
PC_Sort and PC_IsSorted

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@
  - PC_Patch{Min,Max,Avg}(pcpatch) returns pcpoint (#77)
  - PC_Upgrade([<target_version>])
  - PC_Lib_Version(), PC_Script_Version() (#40)
+ - PC_Sort(pcpatch,text[]) (#106)
+ - PC_IsSorted(pcpatch,text[],boolean) (#106)
 - Enhancements
  - Support sigbits encoding for 64bit integers (#61)
  - Warn about truncated values (#68)

--- a/README.md
+++ b/README.md
@@ -464,6 +464,15 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 
 > Returns the n-th point of the patch with 1-based indexing. Negative n counts point from the end. 
 
+**PC_IsSorted(p pcpatch, dimnames text[], strict boolean default true)** returns **boolean**
+
+> Checks whether a pcpatch is sorted lexicographically along the given dimensions. The `strict` option further checks that the ordering is strict (no duplicates).
+
+**PC_Sort(p pcpatch, dimnames text[])** returns **pcpatch**
+
+> Returns a copy of the input patch lexicographically sorted along the given dimensions.
+
+
 ## PostGIS Integration ##
 
 The `pointcloud_postgis` extension adds functions that allow you to use PostgreSQL Pointcloud with PostGIS, converting PcPoint and PcPatch to Geometry and doing spatial filtering on point cloud data. The `pointcloud_postgis` extension depends on both the `postgis` and `pointcloud` extensions, so they must be installed first:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,7 +40,7 @@ set_target_properties (libpc-static
     OUTPUT_NAME "pc"
     PREFIX "lib"
     CLEAN_DIRECT_OUTPUT 1
-    COMPILE_FLAGS "-fPIC -std=gnu89"
+    COMPILE_FLAGS "-fPIC"
   )
 
 set_target_properties (liblazperf-static

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,6 +14,7 @@ set ( PC_SOURCES
         pc_point.c
         pc_pointlist.c
         pc_schema.c
+        pc_sort.c
         pc_stats.c
         pc_util.c
         pc_val.c
@@ -39,7 +40,7 @@ set_target_properties (libpc-static
     OUTPUT_NAME "pc"
     PREFIX "lib"
     CLEAN_DIRECT_OUTPUT 1
-    COMPILE_FLAGS -fPIC
+    COMPILE_FLAGS "-fPIC -std=gnu89"
   )
 
 set_target_properties (liblazperf-static

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -17,6 +17,7 @@ OBJS = \
 	pc_point.o \
 	pc_pointlist.o \
 	pc_schema.o \
+	pc_sort.o \
 	pc_stats.o \
 	pc_util.o \
 	pc_val.o \

--- a/lib/cunit/CMakeLists.txt
+++ b/lib/cunit/CMakeLists.txt
@@ -9,6 +9,7 @@ set (PC_TEST_SOURCES
   cu_pc_schema.c
   cu_pc_patch.c
   cu_pc_patch_lazperf.c
+  cu_pc_sort.c
   cu_tester.c
   )
 

--- a/lib/cunit/Makefile
+++ b/lib/cunit/Makefile
@@ -14,7 +14,8 @@ OBJS =	\
 	cu_pc_point.o \
 	cu_pc_patch.o \
 	cu_pc_patch_ght.o \
-	cu_pc_patch_lazperf.o
+	cu_pc_patch_lazperf.o \
+	cu_pc_sort.o
 
 ifeq ($(CUNIT_LDFLAGS),)
 # No cunit? Emit message and continue

--- a/lib/cunit/cu_pc_sort.c
+++ b/lib/cunit/cu_pc_sort.c
@@ -1,0 +1,390 @@
+/***********************************************************************
+* cu_pc_sort.c
+*
+*        Testing for the schema API functions
+*
+***********************************************************************/
+
+#include "CUnit/Basic.h"
+#include "cu_tester.h"
+
+/* GLOBALS ************************************************************/
+
+static PCSCHEMA *schema = NULL;
+static const char *xmlfile = "data/simple-schema.xml";
+static const double precision = 0.000001;
+
+// SIMPLE SCHEMA
+// int32_t x
+// int32_t y
+// int32_t z
+// int16_t intensity
+
+/* Setup/teardown for this suite */
+static int
+init_suite(void)
+{
+	char *xmlstr = file_to_str(xmlfile);
+	int rv = pc_schema_from_xml(xmlstr, &schema);
+	pcfree(xmlstr);
+	if ( rv == PC_FAILURE ) return 1;
+	return 0;
+}
+
+static int
+clean_suite(void)
+{
+	pc_schema_free(schema);
+	return 0;
+}
+
+/* TESTS **************************************************************/
+
+static void
+test_sort_simple()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000003000000050006 pt1 (XYZi)
+	// 0000000200000001000000040008 pt2 (XYZi)
+
+    // init data
+    PCPOINTLIST *lisort;
+    PCPATCH *pasort;
+    double d1;
+    double d2;
+	char *hexbuf = "0000000000000000000000000200000008000000030000000500060000000200000001000000040008";
+	size_t hexsize = strlen(hexbuf);
+
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *X[] = {"X"};
+
+    // check that initial data are not sorted
+    pc_point_get_double_by_name(pc_pointlist_get_point(li, 0), "X", &d1);
+    pc_point_get_double_by_name(pc_pointlist_get_point(li, 1), "X", &d2);
+
+	CU_ASSERT_DOUBLE_EQUAL(d1, 0.08, precision);
+	CU_ASSERT_DOUBLE_EQUAL(d2, 0.02, precision);
+
+    // sort on X attribute and check if data are well sorted
+    pasort = pc_patch_sort(pa, X, 1);
+    lisort = pc_pointlist_from_patch(pasort);
+
+    pc_point_get_double_by_name(pc_pointlist_get_point(lisort, 0), "X", &d1);
+    pc_point_get_double_by_name(pc_pointlist_get_point(lisort, 1), "X", &d2);
+
+	CU_ASSERT_DOUBLE_EQUAL(d1, 0.02, precision);
+	CU_ASSERT_DOUBLE_EQUAL(d2, 0.08, precision);
+
+    // free
+    pc_pointlist_free(li);
+    pc_pointlist_free(lisort);
+    pc_patch_free(pa);
+    pc_patch_free(pasort);
+    pcfree(wkb);
+}
+
+static void
+test_sort_consistency()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000003000000050006 pt1 (XYZi)
+	// 0000000200000001000000040008 pt2 (XYZi)
+
+    // init data
+    PCPATCH *pasort;
+    char *pastr, *pasortstr;
+    uint8_t *wkbsort;
+	char *hexbuf = "0000000000000000000000000200000008000000030000000500060000000200000001000000040008";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *X[] = {"X"};
+
+    // sort on X attribute
+    pasort = pc_patch_sort(pa, X, 1);
+
+    //chek consistency
+    wkbsort = pc_patch_to_wkb(pasort, &hexsize);
+    CU_ASSERT_EQUAL(wkb_get_pcid(wkb), wkb_get_pcid(wkbsort));
+    CU_ASSERT_EQUAL(wkb_get_npoints(wkb), wkb_get_npoints(wkbsort));
+    CU_ASSERT_EQUAL(wkb_get_compression(wkb), wkb_get_compression(wkbsort));
+
+    pastr = pc_patch_to_string(pa);
+    CU_ASSERT_STRING_EQUAL(pastr, "{\"pcid\":0,\"pts\":[[0.08,0.03,0.05,6],[0.02,0.01,0.04,8]]}");
+
+    pasortstr = pc_patch_to_string(pasort);
+    CU_ASSERT_STRING_EQUAL(pasortstr, "{\"pcid\":0,\"pts\":[[0.02,0.01,0.04,8],[0.08,0.03,0.05,6]]}");
+
+    // free
+    pcfree(wkb);
+    pcfree(wkbsort);
+    pcfree(pastr);
+    pcfree(pasortstr);
+    pc_patch_free(pasort);
+    pc_patch_free(pa);
+    pc_pointlist_free(li);
+}
+
+static void
+test_sort_one_point()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000001 npoints
+	// 0000000200000003000000050006 pt1 (XYZi)
+
+    // init data
+    PCPATCH *pasort;
+    char *pastr, *pasortstr;
+    uint8_t *wkbsort;
+	char *hexbuf = "000000000000000000000000010000000200000003000000050006";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *X[] = {"X"};
+
+    // sort on X attribute
+    pasort = pc_patch_sort(pa, X, 1);
+
+    // check consistency
+    wkbsort = pc_patch_to_wkb(pasort, &hexsize);
+    CU_ASSERT_EQUAL(wkb_get_pcid(wkb), wkb_get_pcid(wkbsort));
+    CU_ASSERT_EQUAL(wkb_get_npoints(wkb), wkb_get_npoints(wkbsort));
+    CU_ASSERT_EQUAL(wkb_get_compression(wkb), wkb_get_compression(wkbsort));
+
+    pastr = pc_patch_to_string(pa);
+    pasortstr = pc_patch_to_string(pasort);
+    CU_ASSERT_STRING_EQUAL(pastr, pasortstr);
+
+    // free
+    pcfree(wkb);
+    pcfree(wkbsort);
+    pcfree(pastr);
+    pcfree(pasortstr);
+    pc_patch_free(pa);
+    pc_patch_free(pasort);
+    pc_pointlist_free(li);
+}
+
+static void
+test_sort_stable()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000003000000050006 pt1 (XYZi)
+	// 0000000200000003000000040008 pt2 (XYZi)
+	// 0000000200000003000000040009 pt3 (XYZi)
+
+    // init data
+    PCPATCH *pasort;
+	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *dims[] = {"Y"};
+
+    // sort on Y attribute
+    pasort = pc_patch_sort(pa, dims, 1);
+
+    // check that sort is stable
+    char *pastr = pc_patch_to_string(pa);
+    char *pasortstr = pc_patch_to_string(pasort);
+    CU_ASSERT_STRING_EQUAL(pastr, pasortstr);
+
+    // free
+    free(pastr);
+    free(pasortstr);
+    pcfree(wkb);
+    pc_patch_free(pa);
+    pc_patch_free(pasort);
+    pc_pointlist_free(li);
+}
+
+static void
+test_sort_patch_is_sorted_no_compression()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000003000000050006 pt1 (XYZi)
+	// 0000000200000003000000040008 pt2 (XYZi)
+	// 0000000200000003000000040009 pt3 (XYZi)
+
+    // init data
+    PCPATCH *pasort;
+	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    PCPOINTLIST *li = pc_pointlist_from_patch(pa);
+    const char *X[] = {"X"};
+
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, X, 1, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, X, 1, PC_TRUE), PC_FALSE);
+
+    pasort = pc_patch_sort(pa, X, 1);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort, X, 1, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort, X, 1, PC_TRUE), PC_TRUE);
+
+    // free
+    pcfree(wkb);
+    pc_patch_free(pa);
+    pc_patch_free(pasort);
+    pc_pointlist_free(li);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional(enum DIMCOMPRESSIONS dimcomp)
+{
+    // init data
+    PCPATCH_DIMENSIONAL *padim1, *padim2, *padimsort;
+    PCPOINT *pt;
+    PCPOINTLIST *pl;
+    int i;
+    int ndims = 1;
+    int npts = PCDIMSTATS_MIN_SAMPLE+1; // force to keep custom compression
+    const char *X[] = {"X"};
+
+    // build a dimensional patch
+    pl = pc_pointlist_make(npts);
+
+    for ( i = npts; i >= 0; i-- )
+    {
+        pt = pc_point_make(schema);
+        pc_point_set_double_by_name(pt, "x", i);
+        pc_point_set_double_by_name(pt, "y", i);
+        pc_point_set_double_by_name(pt, "Z", i);
+        pc_point_set_double_by_name(pt, "intensity", 10);
+        pc_pointlist_add_point(pl, pt);
+    }
+
+    padim1 = pc_patch_dimensional_from_pointlist(pl);
+
+    // set dimensional compression for each dimension
+    PCDIMSTATS *stats = pc_dimstats_make(schema);
+    pc_dimstats_update(stats, padim1);
+    for ( i = 0; i<padim1->schema->ndims; i++ )
+        stats->stats[i].recommended_compression = dimcomp;
+
+    // compress patch
+    padim2 = pc_patch_dimensional_compress(padim1, stats);
+
+    // test that patch is not sorted
+    CU_ASSERT_EQUAL(pc_patch_is_sorted((PCPATCH*) padim2, X, ndims, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted((PCPATCH*) padim2, X, ndims, PC_TRUE), PC_FALSE);
+
+    // sort
+    padimsort = (PCPATCH_DIMENSIONAL*) pc_patch_sort((PCPATCH*) padim2, X, 1);
+
+    // test that resulting data is sorted
+    CU_ASSERT_EQUAL(pc_patch_is_sorted((PCPATCH*) padimsort, X, ndims, PC_TRUE), PC_TRUE);
+
+    // free
+    pc_dimstats_free(stats);
+    pc_patch_free((PCPATCH *)padim1);
+    pc_patch_free((PCPATCH *)padim2);
+    pc_patch_free((PCPATCH *)padimsort);
+    pc_pointlist_free(pl);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional_none()
+{
+    test_sort_patch_is_sorted_compression_dimensional(PC_DIM_NONE);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional_zlib()
+{
+    test_sort_patch_is_sorted_compression_dimensional(PC_DIM_ZLIB);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional_rle()
+{
+    test_sort_patch_is_sorted_compression_dimensional(PC_DIM_RLE);
+}
+
+static void
+test_sort_patch_is_sorted_compression_dimensional_sigbits()
+{
+    test_sort_patch_is_sorted_compression_dimensional(PC_DIM_SIGBITS);
+}
+
+static void
+test_sort_patch_ndims()
+{
+	// 00 endian (big)
+	// 00000000 pcid
+	// 00000000 compression
+	// 00000002 npoints
+	// 0000000800000001000000050006 pt1 (XYZi)
+	// 0000000200000003000000040008 pt2 (XYZi)
+	// 0000000200000002000000040008 pt2 (XYZi)
+
+    // init data
+    PCPATCH *pasort1, *pasort2;
+	char *hexbuf = "00000000000000000000000003000000080000000400000005000600000002000000030000000400080000000200000002000000040009";
+	size_t hexsize = strlen(hexbuf);
+	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
+    const char *X[] = {"X"};
+    const char *Y[] = {"Y"};
+    const char *X_Y[] = {"X", "Y"};
+
+    // test that initial data is not sorted
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, X, 1, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, Y, 1, PC_FALSE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pa, X_Y, 2, PC_FALSE), PC_FALSE);
+
+    // sort on X attribute and test
+    pasort1 = pc_patch_sort(pa, X, 1);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort1, X, 1, PC_TRUE), PC_TRUE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort1, Y, 1, PC_TRUE), PC_FALSE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort1, X_Y, 2, PC_TRUE), PC_FALSE);
+
+    // sort on X and Y and tst
+    pasort2 = pc_patch_sort(pa, X_Y, 2);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort2, X, 1, PC_TRUE), PC_TRUE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort2, Y, 1, PC_TRUE), PC_TRUE);
+    CU_ASSERT_EQUAL(pc_patch_is_sorted(pasort2, X_Y, 2, PC_TRUE), PC_TRUE);
+
+    // free
+    pcfree(wkb);
+    pc_patch_free(pasort1);
+    pc_patch_free(pasort2);
+    pc_patch_free(pa);
+}
+
+/* REGISTER ***********************************************************/
+
+CU_TestInfo sort_tests[] = {
+	PC_TEST(test_sort_simple),
+    PC_TEST(test_sort_consistency),
+    PC_TEST(test_sort_one_point),
+    PC_TEST(test_sort_stable),
+    PC_TEST(test_sort_patch_is_sorted_no_compression),
+    PC_TEST(test_sort_patch_is_sorted_compression_dimensional_none),
+    PC_TEST(test_sort_patch_is_sorted_compression_dimensional_zlib),
+    PC_TEST(test_sort_patch_is_sorted_compression_dimensional_sigbits),
+    PC_TEST(test_sort_patch_is_sorted_compression_dimensional_rle),
+    PC_TEST(test_sort_patch_ndims),
+    CU_TEST_INFO_NULL
+};
+
+CU_SuiteInfo sort_suite = {"sort", init_suite, clean_suite, sort_tests};

--- a/lib/cunit/cu_tester.c
+++ b/lib/cunit/cu_tester.c
@@ -19,6 +19,7 @@ extern CU_SuiteInfo point_suite;
 extern CU_SuiteInfo ght_suite;
 extern CU_SuiteInfo bytes_suite;
 extern CU_SuiteInfo lazperf_suite;
+extern CU_SuiteInfo sort_suite;
 
 /**
  * CUnit error handler
@@ -53,7 +54,8 @@ int main(int argc, char *argv[])
 		point_suite,
 		ght_suite, 
 		bytes_suite, 
-                lazperf_suite,
+		lazperf_suite,
+		sort_suite,
 		CU_SUITE_INFO_NULL
 	};
 

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -436,4 +436,10 @@ PCPATCH* pc_patch_filter_between_by_name(const PCPATCH *pa, const char *name, do
 /** get point n */
 PCPOINT *pc_patch_pointn(const PCPATCH *patch, int n);
 
+/** Sorted patch after reordering points on dimensions */
+PCPATCH *pc_patch_sort(const PCPATCH *pa, const char **name, int ndims);
+
+/** True/false if the patch is sorted on dimension */
+uint32_t pc_patch_is_sorted(const PCPATCH *pa, const char **name, int ndims, char strict);
+
 #endif /* _PC_API_H */

--- a/lib/pc_sort.c
+++ b/lib/pc_sort.c
@@ -10,6 +10,9 @@
 ***********************************************************************/
 #include "pc_api_internal.h"
 #include <assert.h>
+
+
+#include "sort_r/sort_r.h"
 #include <stdlib.h>
 
 // NULL terminated array of PCDIMENSION pointers
@@ -55,7 +58,7 @@ pc_patch_uncompressed_sort(const PCPATCH_UNCOMPRESSED *pu, PCDIMENSION_LIST dim)
     spu->bounds  = pu->bounds;
     spu->stats   = pc_stats_clone(pu->stats);
 
-    qsort_r(spu->data, spu->npoints, pu->schema->size, pc_compare_dim, dim);
+    sort_r(spu->data, spu->npoints, pu->schema->size, pc_compare_dim, dim);
 
     return spu;
 }

--- a/lib/pc_sort.c
+++ b/lib/pc_sort.c
@@ -1,0 +1,267 @@
+/***********************************************************************
+* pc_sort.c
+*
+*  Pointclound patch sorting.
+*
+*  Copyright (c) 2016 IGN
+*
+*  Author: M. Brédif
+*
+***********************************************************************/
+#include "pc_api_internal.h"
+#include <assert.h>
+#include <stdlib.h>
+
+// NULL terminated array of PCDIMENSION pointers
+typedef PCDIMENSION ** PCDIMENSION_LIST;
+
+/**
+ * Comparators
+ */
+
+int
+pc_compare_dim (const void *a, const void *b, void *arg)
+{
+    PCDIMENSION_LIST dim = (PCDIMENSION_LIST)arg;
+    uint32_t byteoffset     = dim[0]->byteoffset;
+    uint32_t interpretation = dim[0]->interpretation;
+    double da = pc_double_from_ptr(a+byteoffset,interpretation);
+    double db = pc_double_from_ptr(b+byteoffset,interpretation);
+    int cmp = ((da > db) - (da < db));
+    return ( cmp == 0 && dim[1]) ? pc_compare_dim(a,b,dim+1) : cmp;
+}
+
+int
+pc_compare_pcb (const void *a, const void *b, const void *arg)
+{
+    PCBYTES *pcb = (PCBYTES *)arg;
+    double da = pc_double_from_ptr(a,pcb->interpretation);
+    double db = pc_double_from_ptr(b,pcb->interpretation);
+    return ((da > db) - (da < db));
+}
+
+
+/**
+ * Sort
+ */
+
+PCPATCH_UNCOMPRESSED *
+pc_patch_uncompressed_sort(const PCPATCH_UNCOMPRESSED *pu, PCDIMENSION_LIST dim)
+{
+    PCPATCH_UNCOMPRESSED *spu = pc_patch_uncompressed_make(pu->schema, pu->npoints);
+
+    memcpy(spu->data, pu->data, pu->datasize);
+    spu->npoints = pu->npoints;
+    spu->bounds  = pu->bounds;
+    spu->stats   = pc_stats_clone(pu->stats);
+
+    qsort_r(spu->data, spu->npoints, pu->schema->size, pc_compare_dim, dim);
+
+    return spu;
+}
+
+PCDIMENSION_LIST pc_schema_get_dimensions_by_name(const PCSCHEMA *schema, const char ** name, int ndims)
+{
+    PCDIMENSION_LIST dim = pcalloc( (ndims+1) * sizeof(PCDIMENSION *));
+    int i;
+    for(i=0; i<ndims; ++i)
+    {
+        dim[i] = pc_schema_get_dimension_by_name(schema, name[i]);
+        if ( ! dim[i] ) {
+            pcerror("dimension \"%s\" does not exist", name[i]);
+            return NULL;
+        }
+        assert(dim[i]->scale>0);
+    }
+    dim[ndims] = NULL;
+    return dim;
+}
+
+PCPATCH *
+pc_patch_sort(const PCPATCH *pa, const char ** name, int ndims)
+{
+    PCDIMENSION_LIST dim = pc_schema_get_dimensions_by_name(pa->schema, name, ndims);
+    PCPATCH *pu = pc_patch_uncompress(pa);
+    if ( !pu ) {
+        pcfree(dim);
+        pcerror("Patch uncompression failed");
+        return NULL;
+    }
+    PCPATCH *ps = (PCPATCH *)pc_patch_uncompressed_sort((PCPATCH_UNCOMPRESSED *)pu, dim);
+    
+    pcfree(dim);
+    if ( pu != pa )
+        pc_patch_free(pu);
+    return ps;
+}
+
+
+/**
+ * IsSorted
+ */
+
+uint32_t
+pc_patch_uncompressed_is_sorted(const PCPATCH_UNCOMPRESSED *pu, PCDIMENSION_LIST dim, char strict)
+{
+    size_t size = pu->schema->size;
+    uint8_t *buf = pu->data, *last = pu->data+pu->datasize-size;
+    while ( buf < last )
+    {
+        if( pc_compare_dim(buf,buf+size,dim) >= strict )
+            return PC_FALSE;
+        buf += size;
+    }
+    return PC_TRUE;
+}
+
+uint32_t
+pc_bytes_uncompressed_is_sorted(const PCBYTES *pcb, char strict)
+{
+    assert(pcb->compression == PC_DIM_NONE);
+    size_t size = pc_interpretation_size(pcb->interpretation);
+    uint8_t *buf  = pcb->bytes;
+    uint8_t *last = buf+pcb->size-size;
+    while ( buf < last )
+    {
+        if( pc_compare_pcb(buf,buf+size,pcb) >= strict )
+            return PC_FALSE;
+        buf += size;
+    }
+    return PC_TRUE;
+}
+
+
+uint32_t
+pc_bytes_sigbits_is_sorted(const PCBYTES *pcb, char strict)
+{
+    assert(pcb->compression == PC_DIM_SIGBITS);
+    pcinfo("%s not implemented, decoding",__func__);
+    PCBYTES dpcb = pc_bytes_decode(*pcb);
+    uint32_t is_sorted = pc_bytes_uncompressed_is_sorted(&dpcb,strict);
+    pc_bytes_free(dpcb);
+    return is_sorted;
+}
+
+uint32_t
+pc_bytes_zlib_is_sorted(const PCBYTES *pcb, char strict)
+{
+    assert(pcb->compression == PC_DIM_ZLIB);
+    pcinfo("%s not implemented, decoding",__func__);
+    PCBYTES dpcb = pc_bytes_decode(*pcb);
+    uint32_t is_sorted = pc_bytes_uncompressed_is_sorted(&dpcb,strict);
+    pc_bytes_free(dpcb);
+    return is_sorted;
+}
+
+
+uint32_t
+pc_bytes_run_length_is_sorted(const PCBYTES *pcb, char strict)
+{
+    assert(pcb->compression == PC_DIM_RLE);
+    uint8_t run;
+    size_t size = pc_interpretation_size(pcb->interpretation);
+    const uint8_t *bytes_rle_curr_val = pcb->bytes + 1;
+    const uint8_t *bytes_rle_next_val = pcb->bytes + 2 + size;
+    const uint8_t *bytes_rle_end_val  = pcb->bytes + pcb->size - size;
+    while( bytes_rle_next_val < bytes_rle_end_val )
+    {
+        run = bytes_rle_curr_val[-1];
+        assert(run>0);
+        if( pc_compare_pcb(bytes_rle_curr_val,bytes_rle_next_val,pcb) >= strict // value comparison
+                || (strict && run > 1) ) // run_length should be 1 if strict
+            return PC_FALSE;
+        bytes_rle_curr_val = bytes_rle_next_val;
+        bytes_rle_next_val += 1 + size;
+    }
+    return PC_TRUE;
+}
+
+
+uint32_t
+pc_patch_dimensional_is_sorted(const PCPATCH_DIMENSIONAL *pdl, PCDIMENSION_LIST dim, char strict)
+{
+    assert(pdl);
+    assert(pdl->schema);
+
+    // uncompress when checking multiple dimensions
+    if(dim[1])
+    {
+        PCPATCH *pu = pc_patch_uncompress((PCPATCH*) pdl);
+        if ( !pu ) {
+            pcerror("Patch uncompression failed");
+            return PC_FAILURE - 1; // aliasing issue : PC_FALSE == PC_FAILURE...
+        }
+        uint32_t res = pc_patch_uncompressed_is_sorted((PCPATCH_UNCOMPRESSED *)pu,dim,strict);
+        pc_patch_free(pu);
+        return res;
+    }
+
+    PCBYTES *pcb = pdl->bytes + dim[0]->position;
+    switch ( pcb->compression )
+    {
+    case PC_DIM_RLE:
+    {
+        return pc_bytes_run_length_is_sorted(pcb,strict);
+    }
+    case PC_DIM_SIGBITS:
+    {
+        return pc_bytes_sigbits_is_sorted(pcb,strict);
+    }
+    case PC_DIM_ZLIB:
+    {
+        return pc_bytes_zlib_is_sorted(pcb,strict);
+    }
+    case PC_DIM_NONE:
+    {
+        return pc_bytes_uncompressed_is_sorted(pcb,strict);
+    }
+    default:
+    {
+        pcerror("%s: Uh oh", __func__);
+    }
+    }
+    return PC_FAILURE;
+}
+
+
+uint32_t
+pc_patch_ght_is_sorted(const PCPATCH_GHT *pa, PCDIMENSION_LIST dim, char strict)
+{
+    PCPATCH *pu = pc_patch_uncompress((PCPATCH*) pa);
+    if ( !pu ) {
+        pcerror("Patch uncompression failed");
+        return PC_FAILURE - 1; // aliasing issue : PC_FALSE == PC_FAILURE...
+    }
+    uint32_t res = pc_patch_uncompressed_is_sorted((PCPATCH_UNCOMPRESSED *)pu,dim,strict);
+    pc_patch_free(pu);
+    return res;
+}
+
+
+uint32_t
+pc_patch_is_sorted(const PCPATCH *pa, const char **name, int ndims, char strict)
+{
+    int res = PC_FAILURE -1; // aliasing issue : PC_FALSE == PC_FAILURE...
+    PCDIMENSION_LIST dim = pc_schema_get_dimensions_by_name(pa->schema, name, ndims);
+    if ( ! dim ) return res;
+    strict = (strict > 0); // ensure 0-1 value
+
+    switch( pa->type )
+    {
+    case PC_NONE:
+        res = pc_patch_uncompressed_is_sorted((PCPATCH_UNCOMPRESSED*)pa,dim,strict); 
+        break;
+    case PC_DIMENSIONAL:
+        res = pc_patch_dimensional_is_sorted((PCPATCH_DIMENSIONAL*)pa,dim,strict);
+        break;
+    case PC_GHT:
+        res = pc_patch_ght_is_sorted((PCPATCH_GHT*)pa,dim,strict);
+        break;
+    default:
+        pcerror("%s: unsupported compression %d requested", __func__, pa->type);
+    }
+    pcfree(dim);
+    return res;
+}
+
+

--- a/lib/sort_r/README.md
+++ b/lib/sort_r/README.md
@@ -1,0 +1,57 @@
+The following README.md and sort_r.h files have been imported from the [noporpoise/sort_r Github project](https://github.com/noporpoise/sort_r) in order to provide a portable reentrant version of qsort.
+
+
+sort_r
+======
+
+Isaac Turner 2013  
+Portable qsort_r / qsort_s  
+Discussion here: http://stackoverflow.com/questions/4300896/how-portable-is-the-re-entrant-qsort-r-function-compared-to-qsort  
+License: Public Domain - use as you wish, no warranty
+
+[![Build Status](https://travis-ci.org/noporpoise/sort_r.png?branch=master)](https://travis-ci.org/noporpoise/sort_r)
+
+About
+-----
+
+If you want to qsort() an array with a comparison operator that takes parameters
+you need to use global variables to pass those parameters (not possible when
+writing multithreaded code), or use qsort_r/qsort_s which are not portable
+(there are separate GNU/BSD/Windows versions and they all take different arguments).
+
+So I wrote a portable qsort_r/qsort_s called sort_r():
+
+    void sort_r(void *base, size_t nel, size_t width,
+                int (*compar)(const void *a1, const void *a2, void *aarg),
+                void *arg);
+
+`base` is the array to be sorted
+`nel` is the number of elements in the array
+`width` is the size in bytes of each element of the array
+`compar` is the comparison function
+`arg` is a pointer to be passed to the comparison function
+
+Using sort_r
+------------
+
+Add `#include "sort_r.h"` to the top of your code. Then copy sort_r.h into your
+working directory, or add -I path/to/sort_r to your compile arguments.
+
+Build Example
+-------------
+
+Compile example code (`example.c`) with:
+
+    make
+
+To build using nested functions and qsort instead of qsort_r use
+
+    make NESTED_QSORT=1
+
+Nested functions are not permitted under ISO C, they are a GCC extension.
+
+License
+-------
+
+Public Domain. Use as you wish. No warranty. There may be bugs.
+

--- a/lib/sort_r/sort_r.h
+++ b/lib/sort_r/sort_r.h
@@ -1,0 +1,224 @@
+/* Isaac Turner 29 April 2014 Public Domain */
+#ifndef SORT_R_H_
+#define SORT_R_H_
+
+#include <stdlib.h>
+#include <string.h>
+
+/*
+
+sort_r function to be exported.
+
+Parameters:
+  base is the array to be sorted
+  nel is the number of elements in the array
+  width is the size in bytes of each element of the array
+  compar is the comparison function
+  arg is a pointer to be passed to the comparison function
+
+void sort_r(void *base, size_t nel, size_t width,
+            int (*compar)(const void *_a, const void *_b, void *_arg),
+            void *arg);
+
+*/
+
+#if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
+     defined __FreeBSD__ || defined __DragonFly__)
+#  define _SORT_R_BSD
+#  define _SORT_R_INLINE inline
+#elif (defined _GNU_SOURCE || defined __gnu_hurd__ || defined __GNU__ || \
+       defined __linux__ || defined __MINGW32__ || defined __GLIBC__)
+#  define _SORT_R_LINUX
+#  define _SORT_R_INLINE inline
+#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
+#  define _SORT_R_WINDOWS
+#  define _SORT_R_INLINE __inline
+#else
+  /* Using our own recursive quicksort sort_r_simple() */
+#endif
+
+#if (defined NESTED_QSORT && NESTED_QSORT == 0)
+#  undef NESTED_QSORT
+#endif
+
+/* swap a, b iff a>b */
+/* __restrict is same as restrict but better support on old machines */
+static _SORT_R_INLINE int sort_r_cmpswap(char *__restrict a, char *__restrict b, size_t w,
+                                         int (*compar)(const void *_a, const void *_b,
+                                                       void *_arg),
+                                         void *arg)
+{
+  char tmp, *end = a+w;
+  if(compar(a, b, arg) > 0) {
+    for(; a < end; a++, b++) { tmp = *a; *a = *b; *b = tmp; }
+    return 1;
+  }
+  return 0;
+}
+
+/* Implement recursive quicksort ourselves */
+/* Note: quicksort is not stable, equivalent values may be swapped */
+static _SORT_R_INLINE void sort_r_simple(void *base, size_t nel, size_t w,
+                                         int (*compar)(const void *_a, const void *_b,
+                                                       void *_arg),
+                                         void *arg)
+{
+  char *b = (char *)base, *end = b + nel*w;
+  if(nel < 7) {
+    /* Insertion sort for arbitrarily small inputs */
+    char *pi, *pj;
+    for(pi = b+w; pi < end; pi += w) {
+      for(pj = pi; pj > b && sort_r_cmpswap(pj-w,pj,w,compar,arg); pj -= w) {}
+    }
+  }
+  else
+  {
+    /* nel > 6; Quicksort */
+
+    /* Use median of first, middle and last items as pivot */
+    char *x, *y, *xend, ch;
+    char *pl, *pr;
+    char *last = b+w*(nel-1), *tmp;
+    char *l[3];
+    l[0] = b;
+    l[1] = b+w*(nel/2);
+    l[2] = last;
+
+    if(compar(l[0],l[1],arg) > 0) { tmp=l[0]; l[0]=l[1]; l[1]=tmp; }
+    if(compar(l[1],l[2],arg) > 0) {
+      tmp=l[1]; l[1]=l[2]; l[2]=tmp; /* swap(l[1],l[2]) */
+      if(compar(l[0],l[1],arg) > 0) { tmp=l[0]; l[0]=l[1]; l[1]=tmp; }
+    }
+
+    /* swap l[id], l[2] to put pivot as last element */
+    for(x = l[1], y = last, xend = x+w; x<xend; x++, y++) {
+      ch = *x; *x = *y; *y = ch;
+    }
+
+    pl = b;
+    pr = last;
+
+    while(pl < pr) {
+      for(; pl < pr; pl += w) {
+        if(sort_r_cmpswap(pl, pr, w, compar, arg)) {
+          pr -= w; /* pivot now at pl */
+          break;
+        }
+      }
+      for(; pl < pr; pr -= w) {
+        if(sort_r_cmpswap(pl, pr, w, compar, arg)) {
+          pl += w; /* pivot now at pr */
+          break;
+        }
+      }
+    }
+
+    sort_r_simple(b, (pl-b)/w, w, compar, arg);
+    sort_r_simple(pl+w, (end-(pl+w))/w, w, compar, arg);
+  }
+}
+
+
+#if defined NESTED_QSORT
+
+  static _SORT_R_INLINE void sort_r(void *base, size_t nel, size_t width,
+                                    int (*compar)(const void *_a, const void *_b,
+                                                  void *aarg),
+                                    void *arg)
+  {
+    int nested_cmp(const void *a, const void *b)
+    {
+      return compar(a, b, arg);
+    }
+
+    qsort(base, nel, width, nested_cmp);
+  }
+
+#else /* !NESTED_QSORT */
+
+  /* Declare structs and functions */
+
+  #if defined _SORT_R_BSD
+
+    /* Ensure qsort_r is defined */
+    extern void qsort_r(void *base, size_t nel, size_t width, void *thunk,
+                        int (*compar)(void *_thunk, const void *_a, const void *_b));
+
+  #endif
+
+  #if defined _SORT_R_BSD || defined _SORT_R_WINDOWS
+
+    /* BSD (qsort_r), Windows (qsort_s) require argument swap */
+
+    struct sort_r_data
+    {
+      void *arg;
+      int (*compar)(const void *_a, const void *_b, void *_arg);
+    };
+
+    static _SORT_R_INLINE int sort_r_arg_swap(void *s, const void *a, const void *b)
+    {
+      struct sort_r_data *ss = (struct sort_r_data*)s;
+      return (ss->compar)(a, b, ss->arg);
+    }
+
+  #endif
+
+  #if defined _SORT_R_LINUX
+
+    typedef int(* __compar_d_fn_t)(const void *, const void *, void *);
+    extern void qsort_r(void *base, size_t nel, size_t width,
+                        __compar_d_fn_t __compar, void *arg)
+      __attribute__((nonnull (1, 4)));
+
+  #endif
+
+  /* implementation */
+
+  static _SORT_R_INLINE void sort_r(void *base, size_t nel, size_t width,
+                                    int (*compar)(const void *_a, const void *_b, void *_arg),
+                                    void *arg)
+  {
+    #if defined _SORT_R_LINUX
+
+      #if defined __GLIBC__ && ((__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 8))
+
+        /* no qsort_r in glibc before 2.8, need to use nested qsort */
+        sort_r_simple(base, nel, width, compar, arg);
+
+      #else
+
+        qsort_r(base, nel, width, compar, arg);
+
+      #endif
+
+    #elif defined _SORT_R_BSD
+
+      struct sort_r_data tmp;
+      tmp.arg = arg;
+      tmp.compar = compar;
+      qsort_r(base, nel, width, &tmp, sort_r_arg_swap);
+
+    #elif defined _SORT_R_WINDOWS
+
+      struct sort_r_data tmp;
+      tmp.arg = arg;
+      tmp.compar = compar;
+      qsort_s(base, nel, width, sort_r_arg_swap, &tmp);
+
+    #else
+
+      /* Fall back to our own quicksort implementation */
+      sort_r_simple(base, nel, width, compar, arg);
+
+    #endif
+  }
+
+#endif /* !NESTED_QSORT */
+
+#undef _SORT_R_INLINE
+#undef _SORT_R_WINDOWS
+#undef _SORT_R_LINUX
+#undef _SORT_R_BSD
+
+#endif /* SORT_R_H_ */

--- a/lib/sort_r/sort_r.h
+++ b/lib/sort_r/sort_r.h
@@ -1,4 +1,6 @@
 /* Isaac Turner 29 April 2014 Public Domain */
+/* http://github.com/noporpoise/sort_r      */
+
 #ifndef SORT_R_H_
 #define SORT_R_H_
 

--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -30,6 +30,8 @@ Datum pcpatch_compression(PG_FUNCTION_ARGS);
 Datum pcpatch_intersects(PG_FUNCTION_ARGS);
 Datum pcpatch_get_stat(PG_FUNCTION_ARGS);
 Datum pcpatch_filter(PG_FUNCTION_ARGS);
+Datum pcpatch_sort(PG_FUNCTION_ARGS);
+Datum pcpatch_is_sorted(PG_FUNCTION_ARGS);
 Datum pcpatch_size(PG_FUNCTION_ARGS);
 Datum pcpoint_size(PG_FUNCTION_ARGS);
 Datum pcpoint_pcid(PG_FUNCTION_ARGS);
@@ -594,6 +596,7 @@ Datum pcpatch_compress(PG_FUNCTION_ARGS)
     /* make sure to avoid stat updates (not sure if needed) */
     stats->total_points = PCDIMSTATS_MIN_SAMPLE+1;
 
+
     /* Fill in per-dimension compression */
     if ( *ptr )
     for (i=0; i<stats->ndims; ++i) {
@@ -968,5 +971,92 @@ Datum pcpatch_filter(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(serpatch_filtered);
 }
 
+const char **array_to_cstring_array(ArrayType *array, int *size)
+{   
+	int i, j, offset = 0;
+	int nelems = ArrayGetNItems(ARR_NDIM(array), ARR_DIMS(array));
+	const char **cstring = nelems ? pcalloc(nelems * sizeof(char*)) : NULL;
+	bits8 *bitmap = ARR_NULLBITMAP(array);
+	for(i=j=0; i<nelems; ++i) 
+	{
+		if(array_get_isnull(bitmap,i)) continue;
+		
+		text *array_text = (text *)(ARR_DATA_PTR(array)+offset);
+		cstring[j++] = text_to_cstring(array_text);
+		offset += INTALIGN(VARSIZE(array_text));
+	}
+	if(size) *size = j;
+	return cstring;
+}
 
+void pc_cstring_array_free(const char **array, int nelems)
+{
+	int i;
+	if(!array) return;
+	for(i=0;i<nelems;++i) pfree((void *)array[i]);
+	pcfree((void *)array);
+}
+
+/**
+* PC_Sort(patch pcpatch, dimname text[]) returns PcPatch
+*/
+PG_FUNCTION_INFO_V1(pcpatch_sort);
+Datum pcpatch_sort(PG_FUNCTION_ARGS)
+{
+	SERIALIZED_PATCH *serpatch = PG_GETARG_SERPATCH_P(0);	
+	ArrayType *array = PG_GETARG_ARRAYTYPE_P(1);
+	int ndims;
+	const char **dim_name = array_to_cstring_array(array,&ndims);
+	if(!ndims)
+	{
+		pc_cstring_array_free(dim_name,ndims);
+		PG_RETURN_POINTER(serpatch);
+	}
+
+	PCSCHEMA *schema = pc_schema_from_pcid(serpatch->pcid, fcinfo);
+	PCPATCH *patch = NULL;
+	PCPATCH *patch_sorted = NULL;
+	SERIALIZED_PATCH *serpatch_sorted = NULL;	
+
+	patch = pc_patch_deserialize(serpatch, schema);
+	if(patch) patch_sorted = pc_patch_sort(patch,dim_name,ndims);	
+
+	pc_cstring_array_free(dim_name,ndims);
+	if(patch) pc_patch_free(patch);
+	PG_FREE_IF_COPY(serpatch, 0);	
+
+	if(!patch_sorted) PG_RETURN_NULL();	
+
+	serpatch_sorted = pc_patch_serialize(patch_sorted,NULL);
+	pc_patch_free(patch_sorted);
+	PG_RETURN_POINTER(serpatch_sorted);
+}
+
+/** True/false if the patch is sorted on dimension */
+PG_FUNCTION_INFO_V1(pcpatch_is_sorted);
+Datum pcpatch_is_sorted(PG_FUNCTION_ARGS)
+{
+	ArrayType *array = PG_GETARG_ARRAYTYPE_P(1);
+	int ndims;
+	const char **dim_name = array_to_cstring_array(array,&ndims);
+	if(!ndims)
+	{
+		pc_cstring_array_free(dim_name,ndims);
+		PG_RETURN_BOOL(PC_TRUE);
+	}
+	SERIALIZED_PATCH *serpatch = PG_GETARG_SERPATCH_P(0);
+	PCSCHEMA *schema = pc_schema_from_pcid(serpatch->pcid, fcinfo);
+	bool strict = PG_GETARG_BOOL(2);
+	PCPATCH *patch = pc_patch_deserialize(serpatch, schema);	
+
+	uint32_t res = pc_patch_is_sorted(patch,dim_name,ndims,strict);	
+
+	pc_cstring_array_free(dim_name,ndims);
+	pc_patch_free(patch);	
+
+	if(res == PC_FAILURE-1)
+		elog(ERROR, "PC_IsSorted failed");
+   
+	PG_RETURN_BOOL(res);
+}
 

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -301,6 +301,14 @@ CREATE OR REPLACE FUNCTION PC_PointN(p pcpatch, n int4)
     RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpatch_pointn'
     LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_Sort(p pcpatch, attr text[])
+        RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_sort'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+      
+CREATE OR REPLACE FUNCTION PC_IsSorted(p pcpatch, attr text[], strict boolean default false)
+        RETURNS boolean AS 'MODULE_PATHNAME', 'pcpatch_is_sorted'
+    LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------


### PR DESCRIPTION
(This is a rebased version of #102, taking into account @pramsey's PCDIMENSION_LIST comment)

This pull request proposes 2 new interrelated functions:
- `PC_Sort( pcpatch, text[] ) : pcpatch`
- `PC_IsSorted( pcpatch, text[], boolean ) : boolean`
#### `PC_Sort( pa pcpatch, attr text[] ) : pcpatch`

(pgpointcloud/pointcloud#54, LI3DS/pointcloud#10) 

Lexicographically sort a patch `pa` on the given dimensions `attr`.

What is natively implemented ?
- [x]  Uncompressed
- [x]  Other compressions fall back to uncompression
- [ ]  Dimensional Uncompressed
- [ ]  Dimensional SigBits
- [ ]  Dimensional Zlib
- [ ]  Dimensional RLE
- [ ]  GHT
- [ ]  LAZPERF

#### `PC_IsSorted( pa pcpatch, attr text[], strict boolean default false ) : boolean`

(LI3DS/pointcloud#9)

Test whether a patch `pa` is lexicographically sorted on the given dimensions `attr`.
The `strict` option requires strict sorting (no duplicates).

What is natively implemented ?
- [x]  Uncompressed
- [x]  Other compressions fall back to uncompression
- [x]  Dimensional Uncompressed (single dimension)
- [ ]  Dimensional SigBits (single dimension)
- [ ]  Dimensional Zlib (single dimension)
- [x]  Dimensional RLE (single dimension)
- [ ]  Dimensional Uncompressed
- [ ]  Dimensional SigBits
- [ ]  Dimensional Zlib
- [ ]  Dimensional RLE
- [ ]  GHT
- [ ]  LAZPERF

#### Contributors
- functionalities : @mbredif
- tests : @pblottiere
