### PR TITLE
Fix compile against PostgreSQL 9.6 on Debian by using correct flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ exec_program(${PG_CONFIG} ARGS --includedir-server
 exec_program(${PG_CONFIG} ARGS --pkglibdir OUTPUT_VARIABLE PGSQL_PKGLIBDIR)
 exec_program(${PG_CONFIG} ARGS --sharedir OUTPUT_VARIABLE PGSQL_SHAREDIR)
 exec_program(${PG_CONFIG} ARGS --bindir OUTPUT_VARIABLE PGSQL_BINDIR)
-exec_program(${PG_CONFIG} ARGS --cppflags OUTPUT_VARIABLE PGSQL_CPPFLAGS)
+exec_program(${PG_CONFIG} ARGS --cflags OUTPUT_VARIABLE PGSQL_CFLAGS)
 exec_program(${PG_CONFIG} ARGS --ldflags OUTPUT_VARIABLE PGSQL_LDFLAGS)
 exec_program(${PG_CONFIG} ARGS --libs OUTPUT_VARIABLE PGSQL_LIBS)
 

--- a/pgsql/CMakeLists.txt
+++ b/pgsql/CMakeLists.txt
@@ -25,7 +25,7 @@ configure_file(
     "${PROJECT_BINARY_DIR}/pgsql/pointcloud.control"
     )
 
-set(CMAKE_C_FLAGS "${PGSQL_CPPFLAGS}")
+set(CMAKE_C_FLAGS "${PGSQL_CFLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${PGSQL_LDFLAGS}")
 
 include_directories ("${PGSQL_INCLUDEDIR_SERVER}")


### PR DESCRIPTION
Fixes issue #118.

pgpointcloud is C, it should be using CLFAGS not CPPFLAGS.