### PR TITLE
Fix unit tests with cunit 2.1-3

### DIFF
--- a/lib/cunit/cu_pc_bytes.c
+++ b/lib/cunit/cu_pc_bytes.c
@@ -541,4 +541,9 @@ CU_TestInfo bytes_tests[] = {
 	CU_TEST_INFO_NULL
 };
 
-CU_SuiteInfo bytes_suite = {"bytes", init_suite, clean_suite, bytes_tests};
+CU_SuiteInfo bytes_suite = {
+    .pName = "bytes",
+    .pInitFunc = init_suite,
+    .pCleanupFunc = clean_suite,
+    .pTests = bytes_tests
+};

--- a/lib/cunit/cu_pc_patch.c
+++ b/lib/cunit/cu_pc_patch.c
@@ -750,4 +750,9 @@ CU_TestInfo patch_tests[] = {
 	CU_TEST_INFO_NULL
 };
 
-CU_SuiteInfo patch_suite = {"patch", init_suite, clean_suite, patch_tests};
+CU_SuiteInfo patch_suite = {
+    .pName = "patch",
+    .pInitFunc = init_suite,
+    .pCleanupFunc = clean_suite,
+    .pTests = patch_tests
+};

--- a/lib/cunit/cu_pc_patch_ght.c
+++ b/lib/cunit/cu_pc_patch_ght.c
@@ -144,4 +144,9 @@ CU_TestInfo ght_tests[] = {
 	CU_TEST_INFO_NULL
 };
 
-CU_SuiteInfo ght_suite = {"ght", init_suite, clean_suite, ght_tests};
+CU_SuiteInfo ght_suite = {
+    .pName = "ght",
+    .pInitFunc = init_suite,
+    .pCleanupFunc = clean_suite,
+    .pTests = ght_tests
+};

--- a/lib/cunit/cu_pc_patch_lazperf.c
+++ b/lib/cunit/cu_pc_patch_lazperf.c
@@ -261,4 +261,9 @@ CU_TestInfo lazperf_tests[] = {
 	CU_TEST_INFO_NULL
 };
 
-CU_SuiteInfo lazperf_suite = {"lazperf", init_suite, clean_suite, lazperf_tests};
+CU_SuiteInfo lazperf_suite = {
+    .pName = "lazperf",
+    .pInitFunc = init_suite,
+    .pCleanupFunc = clean_suite,
+    .pTests = lazperf_tests
+};

--- a/lib/cunit/cu_pc_point.c
+++ b/lib/cunit/cu_pc_point.c
@@ -160,4 +160,9 @@ CU_TestInfo point_tests[] = {
 	CU_TEST_INFO_NULL
 };
 
-CU_SuiteInfo point_suite = {"point", init_suite, clean_suite, point_tests};
+CU_SuiteInfo point_suite = {
+    .pName = "point",
+    .pInitFunc = init_suite,
+    .pCleanupFunc = clean_suite,
+    .pTests = point_tests
+};

--- a/lib/cunit/cu_pc_schema.c
+++ b/lib/cunit/cu_pc_schema.c
@@ -228,4 +228,9 @@ CU_TestInfo schema_tests[] = {
 	CU_TEST_INFO_NULL
 };
 
-CU_SuiteInfo schema_suite = {"schema", init_suite, clean_suite, schema_tests};
+CU_SuiteInfo schema_suite = {
+    .pName = "schema",
+    .pInitFunc = init_suite,
+    .pCleanupFunc = clean_suite,
+    .pTests = schema_tests
+};


### PR DESCRIPTION
The `cu_tester` binary currently segfaults on Debian 9 (Sid). This is because Debian 9 has CUnit 2.1-3, in which the `CU_SuiteInfo` structure has changed.

This PR changes the unit test code in a way that it works with both CUnit 2.1-2 and 2.1-3.