### PR TITLE
Use __attribute__ ((format (printf, x, y)))

### DIFF
--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -25,6 +25,10 @@
 #include "ght.h"
 #endif
 
+#ifndef __GNUC__
+#define __attribute__ (x)
+#endif
+
 /**********************************************************************
 * DATA STRUCTURES
 */
@@ -209,7 +213,8 @@ typedef struct
 typedef void* (*pc_allocator)(size_t size);
 typedef void* (*pc_reallocator)(void *mem, size_t size);
 typedef void  (*pc_deallocator)(void *mem);
-typedef void  (*pc_message_handler)(const char *string, va_list ap);
+typedef void  (*pc_message_handler)(const char *string, va_list ap)
+    __attribute__ (( format (printf, 1, 0) ));
 
 
 

--- a/pgsql/pc_pgsql.c
+++ b/pgsql/pc_pgsql.c
@@ -60,6 +60,10 @@ pgsql_free(void *ptr)
 
 static void
 pgsql_msg_handler(int sig, const char *fmt, va_list ap)
+    __attribute__ (( format (printf, 2, 0) ));
+
+static void
+pgsql_msg_handler(int sig, const char *fmt, va_list ap)
 {
 #define MSG_MAXLEN 1024
 	char msg[MSG_MAXLEN] = {0};
@@ -69,16 +73,25 @@ pgsql_msg_handler(int sig, const char *fmt, va_list ap)
 }
 
 static void
+pgsql_error(const char *fmt, va_list ap) __attribute__ (( format (printf, 1, 0) ));
+
+static void
 pgsql_error(const char *fmt, va_list ap)
 {
 	pgsql_msg_handler(ERROR, fmt, ap);
 }
 
 static void
+pgsql_warn(const char *fmt, va_list ap) __attribute__ (( format (printf, 1, 0) ));
+
+static void
 pgsql_warn(const char *fmt, va_list ap)
 {
 	pgsql_msg_handler(WARNING, fmt, ap);
 }
+
+static void
+pgsql_info(const char *fmt, va_list ap) __attribute__ (( format (printf, 1, 0) ));
 
 static void
 pgsql_info(const char *fmt, va_list ap)


### PR DESCRIPTION
This commit adds `__attribute__ ((format (printf, x, y)))` where it makes sense.

This removes the following compile warning:

```
[ 96%] Building C object pgsql/CMakeFiles/pointcloud.dir/pc_pgsql.c.o
/home/elemoine/src/pointcloud/pgsql/pc_pgsql.c: In function ‘pgsql_msg_handler’:
/home/elemoine/src/pointcloud/pgsql/pc_pgsql.c:66:2: warning: function might be possible candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
  vsnprintf(msg, MSG_MAXLEN, fmt, ap);
  ^~~~~~~~~
```

The compilation is warning-free after this for me!


I hesitated to create a macro for this, so that we don't use `__attribute__` when the compiler is not GNUC. But I am not sure pgpointcloud actually supports other compilers.