### PR TITLE
Remove unused functions and vars

### DIFF
--- a/lib/cunit/cu_pc_bytes.c
+++ b/lib/cunit/cu_pc_bytes.c
@@ -58,13 +58,8 @@ static PCBYTES initbytes(uint8_t *bytes, size_t size, uint32_t interp)
 static void
 test_run_length_encoding()
 {
-	char *bytes, *bytes_rle, *bytes_de_rle;
+	char *bytes;
 	int nr;
-	uint32_t bytes_nelems;
-	size_t bytes_rle_size;
-	size_t size;
-	uint8_t interp;
-	size_t interp_size;
     PCBYTES pcb, epcb, pcb2;
 
 /*
@@ -166,12 +161,10 @@ typedef struct
 static void
 test_sigbits_encoding()
 {
-    int i;
-	uint8_t *bytes, *ebytes;
+	uint8_t *bytes;
     uint16_t *bytes16, *ebytes16;
     uint32_t *bytes32, *ebytes32;
     uint64_t *bytes64, *ebytes64;
-    size_t ebytes_size;
 
 	uint32_t count, nelems;
 	uint8_t common8;
@@ -385,8 +378,7 @@ test_sigbits_encoding()
 static void
 test_zlib_encoding()
 {
-    uint8_t *bytes, *ebytes;
-    uint32_t i;
+    uint8_t *bytes;
     PCBYTES pcb, epcb, pcb2;
     /*
     uint8_t *
@@ -412,7 +404,7 @@ test_zlib_encoding()
 static void
 test_rle_filter()
 {
-	char *bytes, *bytes2;
+	char *bytes;
     PCBYTES pcb, epcb, fpcb;
     PCBITMAP *map1, *map2;
     int i;
@@ -497,8 +489,8 @@ static void
 test_uncompressed_filter()
 {
 	char *bytes;
-    PCBYTES pcb, epcb, fpcb;
-    PCBITMAP *map1, *map2;
+    PCBYTES pcb, fpcb;
+    PCBITMAP *map1;
 
     /*
     typedef struct

--- a/lib/cunit/cu_pc_patch_ght.c
+++ b/lib/cunit/cu_pc_patch_ght.c
@@ -44,11 +44,11 @@ test_patch_ght()
     PCPOINT *pt;
     int i;
     static int npts = 100;
-    PCPOINTLIST *pl1, *pl2;
+    PCPOINTLIST *pl;
     PCPATCH_GHT *pag;
     PCPATCH_UNCOMPRESSED *pu;
 
-    pl1 = pc_pointlist_make(npts);
+    pl = pc_pointlist_make(npts);
 
     for ( i = 0; i < npts; i++ )
     {
@@ -57,11 +57,11 @@ test_patch_ght()
         pc_point_set_double_by_name(pt, "y", 45 + i*0.000001666);
         pc_point_set_double_by_name(pt, "Z", 10 + i*0.34);
         pc_point_set_double_by_name(pt, "intensity", 10);
-        pc_pointlist_add_point(pl1, pt);
+        pc_pointlist_add_point(pl, pt);
     }
 
-    pag = pc_patch_ght_from_pointlist(pl1);
-    pc_pointlist_free(pl1);
+    pag = pc_patch_ght_from_pointlist(pl);
+    pc_pointlist_free(pl);
 
     pu = pc_patch_uncompressed_from_ght(pag);
     CU_ASSERT_EQUAL(npts, pag->npoints);
@@ -94,10 +94,10 @@ test_patch_ght_filtering()
     PCPOINT *pt;
     int i;
     static int npts = 100;
-    PCPOINTLIST *pl1, *pl2;
+    PCPOINTLIST *pl;
     PCPATCH_GHT *pag, *pag_filtered;
     
-    pl1 = pc_pointlist_make(npts);
+    pl = pc_pointlist_make(npts);
 
     for ( i = 0; i < npts; i++ )
     {
@@ -106,11 +106,11 @@ test_patch_ght_filtering()
         pc_point_set_double_by_name(pt, "y", 45 + i*0.000001666);
         pc_point_set_double_by_name(pt, "Z", 10 + i*0.34);
         pc_point_set_double_by_name(pt, "intensity", 10);
-        pc_pointlist_add_point(pl1, pt);
+        pc_pointlist_add_point(pl, pt);
     }
 
-    pag = pc_patch_ght_from_pointlist(pl1);
-    pc_pointlist_free(pl1);
+    pag = pc_patch_ght_from_pointlist(pl);
+    pc_pointlist_free(pl);
 
     pag_filtered = pc_patch_ght_filter(pag, dimnum, PC_LT, 10, 10);
     CU_ASSERT_EQUAL(pag_filtered->npoints, 0);

--- a/lib/cunit/cu_pc_point.c
+++ b/lib/cunit/cu_pc_point.c
@@ -86,7 +86,6 @@ static void
 test_point_access()
 {
 	PCPOINT *pt;
-	int rv;
 	double a1, a2, a3, a4, b1, b2, b3, b4;
 	int idx = 0;
 	double *allvals;
@@ -97,20 +96,20 @@ test_point_access()
 	/* One at a time */
 	idx = 0;
 	a1 = 1.5;
-	rv = pc_point_set_double_by_index(pt, idx, a1);
-	rv = pc_point_get_double_by_index(pt, idx, &b1);
+	pc_point_set_double_by_index(pt, idx, a1);
+	pc_point_get_double_by_index(pt, idx, &b1);
 	// printf("d1=%g, d2=%g\n", a1, b1);
 	CU_ASSERT_DOUBLE_EQUAL(a1, b1, 0.0000001);
 
 	idx = 2;
 	a2 = 1501500.12;
-	rv = pc_point_set_double_by_index(pt, idx, a2);
-	rv = pc_point_get_double_by_index(pt, idx, &b2);
+	pc_point_set_double_by_index(pt, idx, a2);
+	pc_point_get_double_by_index(pt, idx, &b2);
 	CU_ASSERT_DOUBLE_EQUAL(a2, b2, 0.0000001);
 
 	a3 = 91;
-	rv = pc_point_set_double_by_name(pt, "Intensity", a3);
-	rv = pc_point_get_double_by_name(pt, "Intensity", &b3);
+	pc_point_set_double_by_name(pt, "Intensity", a3);
+	pc_point_get_double_by_name(pt, "Intensity", &b3);
 	CU_ASSERT_DOUBLE_EQUAL(a3, b3, 0.0000001);
 
 	pc_point_free(pt);
@@ -121,24 +120,24 @@ test_point_access()
 	a2 = 1501500.12;
 	a3 = 91;
 	a4 = 200;
-	rv = pc_point_set_double_by_index(pt, 0, a1);
-	rv = pc_point_set_double_by_index(pt, 1, a2);
-	rv = pc_point_set_double_by_name(pt, "Intensity", a3);
-	rv = pc_point_set_double_by_name(pt, "Z", a4);
-	rv = pc_point_get_double_by_index(pt, 0, &b1);
-	rv = pc_point_get_double_by_index(pt, 1, &b2);
-	rv = pc_point_get_double_by_name(pt, "Intensity", &b3);
-	rv = pc_point_get_double_by_name(pt, "Z", &b4);
+	pc_point_set_double_by_index(pt, 0, a1);
+	pc_point_set_double_by_index(pt, 1, a2);
+	pc_point_set_double_by_name(pt, "Intensity", a3);
+	pc_point_set_double_by_name(pt, "Z", a4);
+	pc_point_get_double_by_index(pt, 0, &b1);
+	pc_point_get_double_by_index(pt, 1, &b2);
+	pc_point_get_double_by_name(pt, "Intensity", &b3);
+	pc_point_get_double_by_name(pt, "Z", &b4);
 	CU_ASSERT_DOUBLE_EQUAL(a1, b1, 0.0000001);
 	CU_ASSERT_DOUBLE_EQUAL(a2, b2, 0.0000001);
 	CU_ASSERT_DOUBLE_EQUAL(a3, b3, 0.0000001);
 	CU_ASSERT_DOUBLE_EQUAL(a4, b4, 0.0000001);
 
 	/* as a double array */
-	rv = pc_point_set_double_by_index(pt, 0, a1);
-	rv = pc_point_set_double_by_index(pt, 1, a2);
-	rv = pc_point_set_double_by_index(pt, 2, a3);
-	rv = pc_point_set_double_by_index(pt, 3, a4);
+	pc_point_set_double_by_index(pt, 0, a1);
+	pc_point_set_double_by_index(pt, 1, a2);
+	pc_point_set_double_by_index(pt, 2, a3);
+	pc_point_set_double_by_index(pt, 3, a4);
 	allvals = pc_point_to_double_array(pt);
 	CU_ASSERT_DOUBLE_EQUAL(allvals[0], a1, 0.0000001);
 	CU_ASSERT_DOUBLE_EQUAL(allvals[1], a2, 0.0000001);

--- a/lib/pc_patch_ght.c
+++ b/lib/pc_patch_ght.c
@@ -18,36 +18,6 @@
 /* Includes and functions that expect GHT headers and definitions */
 
 #ifdef HAVE_LIBGHT
-static int
-pc_type_from_ght_type(const GhtType ghttype)
-{
-	switch(ghttype)
-	{
-	case GHT_UNKNOWN:
-		return PC_UNKNOWN;
-	case GHT_INT8:
-		return PC_INT8;
-	case GHT_UINT8:
-		return PC_UINT8;
-	case GHT_INT16:
-		return PC_INT16;
-	case GHT_UINT16:
-		return PC_UINT16;
-	case GHT_INT32:
-		return PC_INT32;
-	case GHT_UINT32:
-		return PC_UINT32;
-	case GHT_INT64:
-		return PC_INT64;
-	case GHT_UINT64:
-		return PC_UINT64;
-	case GHT_DOUBLE:
-		return PC_DOUBLE;
-	case GHT_FLOAT:
-		return PC_FLOAT;
-	}
-}
-
 static GhtType
 ght_type_from_pc_type(const int pctype)
 {

--- a/lib/pc_patch_lazperf.c
+++ b/lib/pc_patch_lazperf.c
@@ -88,7 +88,6 @@ pc_patch_uncompressed_from_lazperf(const PCPATCH_LAZPERF *palaz)
 
 	PCPATCH_UNCOMPRESSED *pcu = NULL;
 	uint8_t *decompressed;
-	int i;
 
 	// cpp call to uncompressed data
 	size_t size = lazperf_uncompress_from_compressed(palaz, &decompressed);
@@ -190,7 +189,7 @@ pc_patch_lazperf_from_wkb(const PCSCHEMA *schema, const uint8_t *wkb, size_t wkb
 	PCPATCH_LAZPERF *patch;
 	uint8_t swap_endian = (wkb[0] != machine_endian());
 	uint32_t npoints;
-	size_t datasize, lazperfsize;
+	size_t lazperfsize;
 	const uint8_t *buf;
 
 	if (wkb_get_compression(wkb) != PC_LAZPERF)


### PR DESCRIPTION
When using autotools (as opposed to cmake) the `-Wunused-variable` flag is used, revealing that a number of functions and variables are not used. This PR removes the unused functions and variables.

There's actually one left in `pc_patch.c`:

```
gcc -Wall -O2 -g -fPIC -I/usr/include/libxml2  -I/home/elemoine/local/include -I/home/elemoine/local/include/  -c -o pc_patch.o pc_patch.c                                                                         
pc_patch.c: In function ‘pc_patch_compress’:                                                                                                                                                                       
pc_patch.c:248:21: warning: unused variable ‘pal’ [-Wunused-variable]                                                                                                                                              
    PCPATCH_LAZPERF *pal = pc_patch_lazperf_from_uncompressed((PCPATCH_UNCOMPRESSED*)patch);                                                                                                                       
                     ^~~
```

But this one is more serious, I think it requires an actual fix for an actual bug.