### PR TITLE
Build and test with libght in Travis

### DIFF
--- a/.install-libght.sh
+++ b/.install-libght.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -ex
+git clone https://github.com/pramsey/libght.git
+cd libght; cmake .; make; sudo make install; sudo ldconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,23 @@ install:
   - sudo apt-get install -qq g++-4.8
   - export CXX="g++-4.8"
   - sh .install-lazperf.sh
+  - sh .install-libght.sh
 
 addons:
   postgresql: "9.3" # for "installcheck"
 
-before_script: ./autogen.sh
-
 script:
-  - ./configure CFLAGS="-Wall -O2 -g" --with-lazperf=/usr/local/
+  - ./autogen.sh
+  - ./configure CFLAGS="-Wall -O2 -g" --with-lazperf=/usr/local --with-libght=/usr/local
   - make
   - make check
+# valgrind currently reports many problems with libght. So, for now, and
+# until these problems are fixed, we rebuild pointcloud without libght
+# for the remaining tests
+  - make clean maintainer-clean
+  - ./autogen.sh
+  - ./configure CFLAGS="-Wall -O2 -g" --with-lazperf=/usr/local --without-libght
+  - make
   - valgrind --leak-check=full --error-exitcode=1 lib/cunit/cu_tester
   - sudo make install
   - make installcheck || { cat pgsql/regression.diffs && false; }


### PR DESCRIPTION
This PR suggests changing the Travis script to build and test pointcloud with both lazperf and libght.

Unfortunately the Valgrind check reports many memory issues when pointcloud is compiled with HAVE_LIBGHT defined. And the installcheck target fails as well. So I suggest that we run valgrind and installcheck without libght for now.