### PR TITLE
Change pc_pointlist_from_uncompressed implementation

### DIFF
--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -314,6 +314,9 @@ PCPOINT* pc_point_make(const PCSCHEMA *s);
 /** Create a new readonly PCPOINT on top of a data buffer */
 PCPOINT* pc_point_from_data(const PCSCHEMA *s, const uint8_t *data);
 
+/** Copy the data to the point data, based on the point size */
+void pc_point_copy_data(PCPOINT *pt, const uint8_t *data);
+
 /** Create a new read/write PCPOINT from a double array */
 PCPOINT* pc_point_from_double_array(const PCSCHEMA *s, double *array, uint32_t nelems);
 

--- a/lib/pc_point.c
+++ b/lib/pc_point.c
@@ -64,6 +64,11 @@ pc_point_from_data(const PCSCHEMA *s, const uint8_t *data)
 	return pt;
 }
 
+void
+pc_point_copy_data(PCPOINT *pt, const uint8_t *data)
+{
+    memcpy(pt->data, data, pt->schema->size);
+}
 
 void
 pc_point_free(PCPOINT *pt)

--- a/lib/pc_pointlist.c
+++ b/lib/pc_pointlist.c
@@ -102,7 +102,9 @@ pc_pointlist_from_uncompressed(const PCPATCH_UNCOMPRESSED *patch)
 	pl = pc_pointlist_make(npoints);
 	for ( i = 0; i < npoints; i++ )
 	{
-		pc_pointlist_add_point(pl, pc_point_from_data(patch->schema, patch->data + i*pt_size));
+		PCPOINT *pt = pc_point_make(patch->schema);
+		pc_point_copy_data(pt, patch->data + i * pt_size);
+		pc_pointlist_add_point(pl, pt);
 	}
 	return pl;
 }


### PR DESCRIPTION
Currently `pc_pointlist_from_uncompressed` creates readonly points, that is points whose data is stored in the uncompressed patch's data block.

First, this is inconsisent with the behavior of [`pc_pointlist_from_dimensional`](https://github.com/pgpointcloud/pointcloud/blob/master/lib/pc_pointlist.c#L61-L92), which creates non-readonly points (using the `pc_point_make` function).

This further means that the high-level `pc_pointlist_from_patch` is not consistent, because it returns readonly points for some patch types and non-readonly points for others.

Also, [`pc_pointlist_from_lazperf`](https://github.com/pgpointcloud/pointcloud/blob/master/lib/pc_patch_lazperf.c#L71-L79) and [`pc_pointlist_from_ght`](https://github.com/pgpointcloud/pointcloud/blob/master/lib/pc_patch_ght.c#L574-L580) are currently implemented in terms of `pc_pointlist_from_uncompressed`. The former frees the intermediary uncompressed patch before returning the pointlist, which is not correct because this makes the points point to `free`'d memory. The latter does not free the uncompressed patch, causing a memory leak.

This patch makes `pc_pointlist_from_uncompressed` create non-readonly points instead of readonly points. In this way, `pc_pointlist_from_patch` is consistent, always returning non-readonly points. And it makes it possible to implement `pc_pointlist_from_lazperf` and `pc_pointlist_from_ght` in terms of `pc_pointlist_from_uncompressed`.

When (if) this is merged, [`pc_pointlist_from_ght`](https://github.com/pgpointcloud/pointcloud/blob/master/lib/pc_patch_ght.c#L574-L580)  will still need to be changed, to free the intermediary uncompressed buffer. This will be done with a separate PR.

This patch is an alternative to https://github.com/pgpointcloud/pointcloud/pull/113, which just fixes `pc_pointlist_from_lazperf` by using `pc_point_make` instead of relying on `pc_pointlist_from_uncompressed`.

Please review.