### PR TITLE
pointlist memory fix, pc_pointlist_from_dimensional memory optimization

### DIFF
--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -128,7 +128,7 @@ typedef struct
 
 typedef struct
 {
-	int8_t readonly;
+	void *mem; /* An opaque memory buffer to be freed on destruction if not NULL */
 	uint32_t npoints;
 	uint32_t maxpoints;
 	PCPOINT **points;

--- a/lib/pc_api_internal.h
+++ b/lib/pc_api_internal.h
@@ -180,6 +180,7 @@ PCPATCH_UNCOMPRESSED* pc_patch_uncompressed_make(const PCSCHEMA *s, uint32_t max
 int pc_patch_uncompressed_compute_extent(PCPATCH_UNCOMPRESSED *patch);
 int pc_patch_uncompressed_compute_stats(PCPATCH_UNCOMPRESSED *patch);
 void pc_patch_uncompressed_free(PCPATCH_UNCOMPRESSED *patch);
+uint8_t *pc_patch_uncompressed_readonly(PCPATCH_UNCOMPRESSED *patch);
 PCPOINTLIST* pc_pointlist_from_uncompressed(const PCPATCH_UNCOMPRESSED *patch);
 PCPATCH_UNCOMPRESSED* pc_patch_uncompressed_from_pointlist(const PCPOINTLIST *pl);
 PCPATCH_UNCOMPRESSED* pc_patch_uncompressed_from_dimensional(const PCPATCH_DIMENSIONAL *pdl);
@@ -291,4 +292,3 @@ void pc_bitmap_filter(PCBITMAP *map, PC_FILTERTYPE filter, int i, double d, doub
 
 
 #endif /* _PC_API_INTERNAL_H */
-

--- a/lib/pc_patch_ght.c
+++ b/lib/pc_patch_ght.c
@@ -576,7 +576,10 @@ pc_pointlist_from_ght(const PCPATCH_GHT *pag)
 {
 	PCPATCH_UNCOMPRESSED *pu;
 	pu = pc_patch_uncompressed_from_ght(pag);
-	return pc_pointlist_from_uncompressed(pu);
+	PCPOINTLIST *pl = pc_pointlist_from_uncompressed(pu);
+	pl->mem = pc_patch_uncompressed_readonly(pu);
+	pc_patch_free((PCPATCH *)pu);
+	return pl;
 }
 
 

--- a/lib/pc_patch_lazperf.c
+++ b/lib/pc_patch_lazperf.c
@@ -74,6 +74,7 @@ pc_pointlist_from_lazperf(const PCPATCH_LAZPERF *palaz)
 	PCPATCH_UNCOMPRESSED *pu = NULL;
 	pu = pc_patch_uncompressed_from_lazperf(palaz);
 	PCPOINTLIST *pl = pc_pointlist_from_uncompressed(pu);
+	pl->mem = pc_patch_uncompressed_readonly(pu);
 	pc_patch_free((PCPATCH *)pu);
 	return pl;
 }

--- a/lib/pc_patch_uncompressed.c
+++ b/lib/pc_patch_uncompressed.c
@@ -222,6 +222,15 @@ pc_patch_uncompressed_free(PCPATCH_UNCOMPRESSED *patch)
 	pcfree(patch);
 }
 
+// Make the patch readonly. Return the memory segment
+// owned by the patch, if any, to enable transfer of ownership
+uint8_t *
+pc_patch_uncompressed_readonly(PCPATCH_UNCOMPRESSED *patch)
+{
+	uint8_t *data = patch->readonly ? NULL : patch->data;
+	patch->readonly = PC_TRUE;
+	return data;
+}
 
 
 PCPATCH_UNCOMPRESSED *


### PR DESCRIPTION
@elemoine , @strk, this is an alternative PR to #135, with cleaner semantics (I think).

- The readonly attribute of pointlist was never used. I propose to change it for an opaque memory pointer `mem`, that will point to the data owned by the pointlist, if any so that it can be freed upon destruction.

- The new function `pc_patch_uncompressed_readonly` makes the patch readonly and return the disowned `data`, if any, to enable transfer ownership (eg: affectation to the `pointlist->mem` pointer

- As a bonus, pc_pointlist_from_dimensional can now be implemented with a single pcalloc/patch rather than point.