### PR TITLE
Remove compile warning

### DIFF
--- a/lib/cunit/cu_pc_patch_lazperf.c
+++ b/lib/cunit/cu_pc_patch_lazperf.c
@@ -34,6 +34,7 @@ clean_suite(void)
 	return 0;
 }
 
+#ifdef HAVE_LAZPERF
 static void
 test_schema_compression_lazperf(void)
 {
@@ -50,7 +51,6 @@ test_schema_compression_lazperf(void)
 	pcfree(xmlstr);
 }
 
-#ifdef HAVE_LAZPERF
 static void
 test_patch_lazperf()
 {


### PR DESCRIPTION
When using `./configure CFLAGS="-Wall -O2 -g"` we get an "unused-function" warning at compile time. This was raised by @strk in #130. This commit fixes the issue.