### PR TITLE
pc_point_to_geometry_wkb : get_m fix

### DIFF
--- a/lib/pc_point.c
+++ b/lib/pc_point.c
@@ -379,7 +379,7 @@ pc_point_to_geometry_wkb(const PCPOINT *pt, size_t *wkbsize)
 
 	if ( pt->schema->m_position > -1 )
 	{
-		m = pc_point_get_z(pt);
+		m = pc_point_get_m(pt);
 		memcpy(ptr, &m, 8); /* M */
 		ptr += 8;
 	}


### PR DESCRIPTION
A typo was introduced while rebasing this PR: `z` values were assigned to both `z` and `m` output points