### PR TITLE
Add z and m to PCBounds

### DIFF
--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -150,6 +150,10 @@ typedef struct
 	double xmax;
 	double ymin;
 	double ymax;
+	double zmin;
+	double zmax;
+	double mmin;
+	double mmax;
 } PCBOUNDS;
 
 /* Used for generic patch statistics */

--- a/lib/pc_api_internal.h
+++ b/lib/pc_api_internal.h
@@ -269,11 +269,13 @@ void pc_bytes_to_ptr(uint8_t *buf, PCBYTES pcb, int n);
 */
 
 /** Initialize with very large mins and very small maxes */
-void pc_bounds_init(PCBOUNDS *b);
+void pc_bounds_init(PCBOUNDS *b, const PCSCHEMA *schema);
 /** Copy a bounds */
 PCSTATS* pc_stats_clone(const PCSTATS *stats);
 /** Expand extents of b1 to encompass b2 */
 void pc_bounds_merge(PCBOUNDS *b1, const PCBOUNDS *b2);
+/** Expand extents of b to encompass p */
+void pc_bounds_expand(PCBOUNDS *b, const PCPOINT *p);
 
 /****************************************************************************
 * BITMAPS

--- a/lib/pc_filter.c
+++ b/lib/pc_filter.c
@@ -165,7 +165,7 @@ pc_patch_dimensional_filter(const PCPATCH_DIMENSIONAL *pdl, const PCBITMAP *map)
 		stats.max = pc_value_scale_offset(stats.max, dim);
 		stats.sum = pc_value_scale_offset(stats.sum, dim);
 
-		/* Save the X/Y stats for use in bounds later */
+		/* Save the XYZM stats for use in bounds later */
 		if ( i == pdl->schema->x_position )
 		{
 			fpdl->bounds.xmin = stats.min;
@@ -175,6 +175,16 @@ pc_patch_dimensional_filter(const PCPATCH_DIMENSIONAL *pdl, const PCBITMAP *map)
 		{
 			fpdl->bounds.ymin = stats.min;
 			fpdl->bounds.ymax = stats.max;
+		}
+		else if ( i == pdl->schema->z_position )
+		{
+			fpdl->bounds.zmin = stats.min;
+			fpdl->bounds.zmax = stats.max;
+		}
+		else if ( i == pdl->schema->m_position )
+		{
+			fpdl->bounds.mmin = stats.min;
+			fpdl->bounds.mmax = stats.max;
 		}
 
 		pc_point_set_double_by_index(&(fpdl->stats->min), i, stats.min);

--- a/lib/pc_patch_dimensional.c
+++ b/lib/pc_patch_dimensional.c
@@ -21,7 +21,7 @@ typedef struct
 	int8_t readonly;
 	const PCSCHEMA *schema;
 	uint32_t npoints;
-	double xmin, xmax, ymin, ymax;
+	double xmin, xmax, ymin, ymax, zmin, zmax, mmin, mmax;
 	PCSTATS *stats;
 	PCBYTES *bytes;
 } PCPATCH_DIMENSIONAL;
@@ -179,30 +179,54 @@ pc_patch_dimensional_free(PCPATCH_DIMENSIONAL *pdl)
 int
 pc_patch_dimensional_compute_extent(PCPATCH_DIMENSIONAL *pdl)
 {
-	double xmin, xmax, ymin, ymax, xavg, yavg;
+	double min, max, avg;
 	int rv;
 	PCBYTES *pcb;
 
 	assert(pdl);
 	assert(pdl->schema);
 
+	pc_bounds_init(&(pdl->bounds), pdl->schema);
+
 	/* Get x extremes */
-	pcb = &(pdl->bytes[pdl->schema->x_position]);
-	rv = pc_bytes_minmax(pcb, &xmin, &xmax, &xavg);
-	if ( PC_FAILURE == rv ) return PC_FAILURE;
-	xmin = pc_value_scale_offset(xmin, pdl->schema->dims[pdl->schema->x_position]);
-	xmax = pc_value_scale_offset(xmax, pdl->schema->dims[pdl->schema->x_position]);
-	pdl->bounds.xmin = xmin;
-	pdl->bounds.xmax = xmax;
+	if ( pdl->schema->x_position != -1 )
+	{
+		pcb = &(pdl->bytes[pdl->schema->x_position]);
+		rv = pc_bytes_minmax(pcb, &min, &max, &avg);
+		if ( PC_FAILURE == rv ) return PC_FAILURE;
+		pdl->bounds.xmin = pc_value_scale_offset(min, pdl->schema->dims[pdl->schema->x_position]);
+		pdl->bounds.xmax = pc_value_scale_offset(max, pdl->schema->dims[pdl->schema->x_position]);
+	}
 
 	/* Get y extremes */
-	pcb = &(pdl->bytes[pdl->schema->y_position]);
-	rv = pc_bytes_minmax(pcb, &ymin, &ymax, &yavg);
-	if ( PC_FAILURE == rv ) return PC_FAILURE;
-	ymin = pc_value_scale_offset(ymin, pdl->schema->dims[pdl->schema->y_position]);
-	ymax = pc_value_scale_offset(ymax, pdl->schema->dims[pdl->schema->y_position]);
-	pdl->bounds.ymin = ymin;
-	pdl->bounds.ymax = ymax;
+	if ( pdl->schema->y_position != -1 )
+	{
+		pcb = &(pdl->bytes[pdl->schema->y_position]);
+		rv = pc_bytes_minmax(pcb, &min, &max, &avg);
+		if ( PC_FAILURE == rv ) return PC_FAILURE;
+		pdl->bounds.ymin = pc_value_scale_offset(min, pdl->schema->dims[pdl->schema->y_position]);
+		pdl->bounds.ymax = pc_value_scale_offset(max, pdl->schema->dims[pdl->schema->y_position]);
+	}
+
+	/* Get z extremes */
+	if ( pdl->schema->z_position != -1 )
+	{
+		pcb = &(pdl->bytes[pdl->schema->z_position]);
+		rv = pc_bytes_minmax(pcb, &min, &max, &avg);
+		if ( PC_FAILURE == rv ) return PC_FAILURE;
+		pdl->bounds.zmin = pc_value_scale_offset(min, pdl->schema->dims[pdl->schema->z_position]);
+		pdl->bounds.zmax = pc_value_scale_offset(max, pdl->schema->dims[pdl->schema->z_position]);
+	}
+
+	/* Get m extremes */
+	if ( pdl->schema->m_position != -1 )
+	{
+		pcb = &(pdl->bytes[pdl->schema->m_position]);
+		rv = pc_bytes_minmax(pcb, &min, &max, &avg);
+		if ( PC_FAILURE == rv ) return PC_FAILURE;
+		pdl->bounds.mmin = pc_value_scale_offset(min, pdl->schema->dims[pdl->schema->m_position]);
+		pdl->bounds.mmax = pc_value_scale_offset(max, pdl->schema->dims[pdl->schema->m_position]);
+	}
 
 	return PC_SUCCESS;
 }

--- a/lib/pc_patch_ght.c
+++ b/lib/pc_patch_ght.c
@@ -402,6 +402,12 @@ pc_patch_ght_compute_extent(PCPATCH_GHT *patch)
 	patch->bounds.ymin = area.y.min;
 	patch->bounds.ymax = area.y.max;
 
+	// provide a conservative non-discriminative bounding box
+	patch->bounds.zmin = -DBLMAX;
+	patch->bounds.zmax =  DBLMAX;
+	patch->bounds.mmin = -DBLMAX;
+	patch->bounds.mmax =  DBLMAX;
+
 	// ght_tree_free(tree);
 
 	return PC_SUCCESS;

--- a/lib/pc_patch_uncompressed.c
+++ b/lib/pc_patch_uncompressed.c
@@ -180,7 +180,7 @@ pc_patch_uncompressed_make(const PCSCHEMA *s, uint32_t maxpoints)
 	{
 		pch->data = pcalloc(datasize);
 	}
-	pc_bounds_init(&(pch->bounds));
+	pc_bounds_init(&(pch->bounds), s);
 
 	return pch;
 }
@@ -190,24 +190,16 @@ pc_patch_uncompressed_compute_extent(PCPATCH_UNCOMPRESSED *patch)
 {
 	int i;
 	PCPOINT *pt = pc_point_from_data(patch->schema, patch->data);
-	PCBOUNDS b;
-	double x, y;
 
 	/* Calculate bounds */
-	pc_bounds_init(&b);
+	pc_bounds_init(&(patch->bounds), patch->schema);
 	for ( i = 0; i < patch->npoints; i++ )
 	{
 		/* Just push the data buffer forward by one point at a time */
 		pt->data = patch->data + i * patch->schema->size;
-		x = pc_point_get_x(pt);
-		y = pc_point_get_y(pt);
-		if ( b.xmin > x ) b.xmin = x;
-		if ( b.ymin > y ) b.ymin = y;
-		if ( b.xmax < x ) b.xmax = x;
-		if ( b.ymax < y ) b.ymax = y;
+		pc_bounds_expand(&(patch->bounds), pt);
 	}
 
-	patch->bounds = b;
 	pcfree(pt);
 	return PC_SUCCESS;
 }
@@ -282,7 +274,7 @@ pc_patch_uncompressed_from_pointlist(const PCPOINTLIST *pl)
 	ptr = pch->data;
 
 	/* Initialize bounds */
-	pc_bounds_init(&(pch->bounds));
+	pc_bounds_init(&(pch->bounds), s);
 
 	/* Set up basic info */
 	pch->readonly = PC_FALSE;
@@ -376,7 +368,6 @@ pc_patch_uncompressed_add_point(PCPATCH_UNCOMPRESSED *c, const PCPOINT *p)
 {
 	size_t sz;
 	uint8_t *ptr;
-	double x, y;
 
 	if ( ! ( c && p ) )
 	{
@@ -418,12 +409,7 @@ pc_patch_uncompressed_add_point(PCPATCH_UNCOMPRESSED *c, const PCPOINT *p)
 	c->npoints += 1;
 
 	/* Update bounding box */
-	x = pc_point_get_x(p);
-	y = pc_point_get_y(p);
-	if ( c->bounds.xmin > x ) c->bounds.xmin = x;
-	if ( c->bounds.ymin > y ) c->bounds.ymin = y;
-	if ( c->bounds.xmax < x ) c->bounds.xmax = x;
-	if ( c->bounds.ymax < y ) c->bounds.ymax = y;
+	pc_bounds_expand(&(c->bounds), p);
 
 	return PC_SUCCESS;
 }

--- a/lib/pc_util.c
+++ b/lib/pc_util.c
@@ -241,7 +241,11 @@ pc_bounds_intersects(const PCBOUNDS *b1, const PCBOUNDS *b2)
 	if (	b1->xmin > b2->xmax ||
 		b1->xmax < b2->xmin ||
 		b1->ymin > b2->ymax ||
-		b1->ymax < b2->ymin )
+		b1->ymax < b2->ymin ||
+		b1->zmin > b2->zmax ||
+		b1->zmax < b2->zmin ||
+		b1->mmin > b2->mmax ||
+		b1->mmax < b2->mmin )
 	{
 		return PC_FALSE;
 	}
@@ -249,17 +253,60 @@ pc_bounds_intersects(const PCBOUNDS *b1, const PCBOUNDS *b2)
 }
 
 void
-pc_bounds_init(PCBOUNDS *b)
+pc_bounds_init(PCBOUNDS *b, const PCSCHEMA *schema)
 {
-	b->xmin = b->ymin = DBL_MAX;
-	b->xmax = b->ymax = -1*DBL_MAX;
+	b->xmin = (schema->x_position == -1) ? -DBL_MAX : DBL_MAX;
+	b->ymin = (schema->y_position == -1) ? -DBL_MAX : DBL_MAX;
+	b->zmin = (schema->z_position == -1) ? -DBL_MAX : DBL_MAX;
+	b->mmin = (schema->m_position == -1) ? -DBL_MAX : DBL_MAX;
+
+	b->xmax = -b->xmin;
+	b->ymax = -b->ymin;
+	b->zmax = -b->zmin;
+	b->mmax = -b->mmin;
 }
 
 void pc_bounds_merge(PCBOUNDS *b1, const PCBOUNDS *b2)
 {
 	if ( b2->xmin < b1->xmin ) b1->xmin = b2->xmin;
 	if ( b2->ymin < b1->ymin ) b1->ymin = b2->ymin;
+	if ( b2->zmin < b1->zmin ) b1->zmin = b2->zmin;
+	if ( b2->mmin < b1->mmin ) b1->mmin = b2->mmin;
 	if ( b2->xmax > b1->xmax ) b1->xmax = b2->xmax;
 	if ( b2->ymax > b1->ymax ) b1->ymax = b2->ymax;
+	if ( b2->zmax > b1->zmax ) b1->zmax = b2->zmax;
+	if ( b2->mmax > b1->mmax ) b1->mmax = b2->mmax;
 }
 
+void pc_bounds_expand(PCBOUNDS *b, const PCPOINT *p)
+{
+	double v;
+
+	if ( p->schema->x_position > -1 )
+	{
+		v = pc_point_get_x(p);
+		if ( b->xmin > v ) b->xmin = v;
+		if ( b->xmax < v ) b->xmax = v;
+	}
+
+	if ( p->schema->y_position > -1 )
+	{
+		v = pc_point_get_y(p);
+		if ( b->ymin > v ) b->ymin = v;
+		if ( b->ymax < v ) b->ymax = v;
+	}
+
+	if ( p->schema->z_position > -1 )
+	{
+		v = pc_point_get_z(p);
+		if ( b->zmin > v ) b->zmin = v;
+		if ( b->zmax < v ) b->zmax = v;
+	}
+
+	if ( p->schema->m_position > -1 )
+	{
+		v = pc_point_get_m(p);
+		if ( b->mmin > v ) b->mmin = v;
+		if ( b->mmax < v ) b->mmax = v;
+	}
+}

--- a/pgsql/expected/pointcloud-ght.out
+++ b/pgsql/expected/pointcloud-ght.out
@@ -62,7 +62,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_ght;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_ght;
  sum 
 -----
- 582
+ 710
 (1 row)
 
 SELECT Sum(PC_PatchMax(pa,'x')) FROM pa_test_ght;
@@ -98,7 +98,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_ght;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_ght;
   sum  
 -------
- 38681
+ 38809
 (1 row)
 
 SELECT Max(PC_PatchMax(pa,'x')) FROM pa_test_ght;

--- a/pgsql/expected/pointcloud-laz.out
+++ b/pgsql/expected/pointcloud-laz.out
@@ -96,7 +96,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_laz;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_laz;
  sum 
 -----
- 487
+ 615
 (1 row)
 
 SELECT Sum(PC_PatchMax(pa,'x')) FROM pa_test_laz;
@@ -192,7 +192,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_laz;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_laz;
  sum  
 ------
- 1499
+ 1659
 (1 row)
 
 SELECT Max(PC_PatchMax(pa,'x')) FROM pa_test_laz;

--- a/pgsql/expected/pointcloud.out
+++ b/pgsql/expected/pointcloud.out
@@ -334,7 +334,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_dim;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_dim;
  sum 
 -----
- 684
+ 812
 (1 row)
 
 SELECT Sum(PC_PatchMax(pa,'x')) FROM pa_test_dim;
@@ -370,7 +370,7 @@ SELECT Sum(PC_NumPoints(pa)) FROM pa_test_dim;
 SELECT Sum(PC_MemSize(pa)) FROM pa_test_dim;
  sum  
 ------
- 8733
+ 8893
 (1 row)
 
 SELECT Max(PC_PatchMax(pa,'x')) FROM pa_test_dim;


### PR DESCRIPTION
I am creating this PR for discussion, on behalf of @mbredif and myself.

Currently, the [bounds](https://github.com/pgpointcloud/pointcloud/blob/60e10e31ef7114f7819456f4f9ed065e10278013/lib/pc_api.h#L147-L153) that we store in patches are 2D. This is a limitation.

For example, `PC_Intersects(p1, p2)`, which checks whether the bounds of `p1` and `p2` intersect, works in [2D only](https://github.com/pgpointcloud/pointcloud/blob/60e10e31ef7114f7819456f4f9ed065e10278013/lib/pc_util.c#L238-L249). Also, `geometry(p)` currently [returns](https://github.com/pgpointcloud/pointcloud/blob/60e10e31ef7114f7819456f4f9ed065e10278013/pgsql_postgis/pointcloud_postgis--1.0.sql#L16-L26) a 2D polygon. So with an index on `geometry(p)` only 2D spatial relationship tests are possible.

To address these limitations this PR suggests adding `zmin`, `zmax`, `mmin` and `mmax` to `PCBOUNDS`.

One issue is the change to the patch format, making "old" patch data incompatible with newer versions of pointcloud. I think this is not acceptable. One way to address that problem might be to use some bits of the [current patch header](https://github.com/pgpointcloud/pointcloud/blob/60e10e31ef7114f7819456f4f9ed065e10278013/lib/pc_api.h#L172-L178) to store some version number. For example, we could steal some bits from `type`, which only requires [4 bits](https://github.com/pgpointcloud/pointcloud/blob/60e10e31ef7114f7819456f4f9ed065e10278013/lib/pc_api.h#L36-L45) at the moment.

What do you think? Do you agree with extending `PCBOUNDS`? Does the idea of stealing bits from `type` to encode some version in the data sound valid? Stupid? Do you see other way to address the "patch data compatibility" issue?