### PR TITLE
Make it possible to have multiple SQL files

### DIFF
--- a/pgsql/CMakeLists.txt
+++ b/pgsql/CMakeLists.txt
@@ -15,8 +15,25 @@ set ( PC_INSTALL_EXENSIONS
   "${PROJECT_BINARY_DIR}/pgsql/pointcloud.control"
   )
 
+set ( PC_SQLS
+  pointcloud.sql.in
+  )
+
+# create a "cat" function, used for concatenating the sql.in files
+# in PC_SQLS into one sql.in file
+function(cat IN_FILE OUT_FILE)
+  file(READ ${IN_FILE} CONTENTS)
+  file(APPEND ${OUT_FILE} "${CONTENTS}")
+endfunction()
+
+# concatenate the sql.in files
+file(WRITE pointcloud--${POINTCLOUD_VERSION}.sql.in "")
+foreach(SQL ${PC_SQLS})
+  cat(${SQL} pointcloud--${POINTCLOUD_VERSION}.sql.in)
+endforeach()
+
 configure_file(
-    pointcloud.sql.in
+    pointcloud--${POINTCLOUD_VERSION}.sql.in
     "${PROJECT_BINARY_DIR}/pgsql/pointcloud--${POINTCLOUD_VERSION}.sql"
     )
 

--- a/pgsql/Makefile
+++ b/pgsql/Makefile
@@ -48,8 +48,8 @@ $(EXTENSION).control: $(EXTENSION).control.in Makefile
 	$(SED) -e 's/@POINTCLOUD_VERSION@/$(EXTVERSION)/' \
          -e 's/@POINTCLOUD_VERSION_MAJOR@/$(EXTVERSION_MAJOR)/' $< > $@
 
-$(EXTENSION)--$(EXTVERSION).sql: $(EXTENSION).sql.in Makefile
-	$(SED) -e 's/@POINTCLOUD_VERSION@/$(EXTVERSION)/' $< > $@
+$(EXTENSION)--$(EXTVERSION).sql: $(EXTENSION).sql.in *.sql.in Makefile
+	$(SED) -e 's/@POINTCLOUD_VERSION@/$(EXTVERSION)/' $(filter-out Makefile, $^) > $@
 
 # NOTE: relies on PERL being defined by PGXS
 $(EXTENSION)--%--$(EXTVERSION).sql: $(EXTENSION)--$(EXTVERSION).sql ../util/proc_upgrade.pl


### PR DESCRIPTION
This PR introduces minor changes to the pgsql `CMakeLists.txt` and `Makefile` files. These changes have no impact on the pointcloud build, but they ease the maintainance of our pointcloud version by making it possible to have multiple SQL files in the pointcloud extension.