### PR TITLE
Change non-breaking space to regular space

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -344,7 +344,7 @@ if test "x$LAZPERFDIR" = "x"; then
 		  [FOUND_LAZPERF="YES"],
 		  [FOUND_LAZPERF="NO"])
 elif test "x$LAZPERFDIR" != "xno"; then
-  dnl LAZPERFDIR was specified, so let's look there!
+  dnl LAZPERFDIR was specified, so let's look there!
 
   LAZPERF_CPPFLAGS="-I${LAZPERFDIR}/include/"
 


### PR DESCRIPTION
This tiny patch changes a non-breaking space character to a regular space character in `configure.ac`.