### PR TITLE
Add PC_Range(p PCPATCH, first int4, count int4)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@
  - PC_Lib_Version(), PC_Script_Version() (#40)
  - PC_Sort(pcpatch,text[]) (#106)
  - PC_IsSorted(pcpatch,text[],boolean) (#106)
+ - PC_Range(pcpatch, int, int) returns pcpatch (#152)
 - Enhancements
  - Support sigbits encoding for 64bit integers (#61)
  - Warn about truncated values (#68)

--- a/README.md
+++ b/README.md
@@ -471,6 +471,9 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 
 > Returns a copy of the input patch lexicographically sorted along the given dimensions.
 
+**PC_Range(p pcpatch, start int4, n int4)** returns **pcpatch**
+
+> Returns a patch containing *n* points. These points are selected from the *start*-th point with 1-based indexing.
 
 ## PostGIS Integration ##
 

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -458,4 +458,7 @@ PCPATCH *pc_patch_sort(const PCPATCH *pa, const char **name, int ndims);
 /** True/false if the patch is sorted on dimension */
 uint32_t pc_patch_is_sorted(const PCPATCH *pa, const char **name, int ndims, char strict);
 
+/** Subset batch based on index */
+PCPATCH* pc_patch_range(const PCPATCH *pa, int first, int count);
+
 #endif /* _PC_API_H */

--- a/pgsql/expected/pointcloud.out
+++ b/pgsql/expected/pointcloud.out
@@ -312,6 +312,15 @@ SELECT sum(PC_NumPoints(pa)) FROM pa_test;
    8
 (1 row)
 
+SELECT PC_AsText(PC_Range(pa, 1, 1)) FROM pa_test;
+               pc_astext               
+---------------------------------------
+ {"pcid":1,"pts":[[0.02,0.03,0.05,6]]}
+ {"pcid":1,"pts":[[0.06,0.07,0.05,6]]}
+ {"pcid":1,"pts":[[0.06,0.07,0.05,6]]}
+ {"pcid":1,"pts":[[0.06,0.07,0.05,6]]}
+(4 rows)
+
 CREATE TABLE IF NOT EXISTS pa_test_dim (
     pa PCPATCH(3)
 );

--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -28,6 +28,7 @@ Datum pcpatch_uncompress(PG_FUNCTION_ARGS);
 Datum pcpatch_compress(PG_FUNCTION_ARGS);
 Datum pcpatch_numpoints(PG_FUNCTION_ARGS);
 Datum pcpatch_pointn(PG_FUNCTION_ARGS);
+Datum pcpatch_range(PG_FUNCTION_ARGS);
 Datum pcpatch_pcid(PG_FUNCTION_ARGS);
 Datum pcpatch_summary(PG_FUNCTION_ARGS);
 Datum pcpatch_compression(PG_FUNCTION_ARGS);
@@ -675,6 +676,29 @@ Datum pcpatch_pointn(PG_FUNCTION_ARGS)
 	serpt = pc_point_serialize(pt);
 	pc_point_free(pt);
 	PG_RETURN_POINTER(serpt);
+}
+
+PG_FUNCTION_INFO_V1(pcpatch_range);
+Datum pcpatch_range(PG_FUNCTION_ARGS)
+{
+	SERIALIZED_PATCH *serpaout;
+	SERIALIZED_PATCH *serpa = PG_GETARG_SERPATCH_P(0);
+	int32 first = PG_GETARG_INT32(1);
+	int32 count = PG_GETARG_INT32(2);
+	PCSCHEMA *schema = pc_schema_from_pcid(serpa->pcid, fcinfo);
+	PCPATCH *patch = pc_patch_deserialize(serpa, schema);
+	PCPATCH *patchout = NULL;
+	if ( patch )
+	{
+		patchout = pc_patch_range(patch, first, count);
+		if ( patchout != patch )
+			pc_patch_free(patch);
+	}
+	if ( !patchout )
+		PG_RETURN_NULL();
+	serpaout = pc_patch_serialize(patchout, NULL);
+	pc_patch_free(patchout);
+	PG_RETURN_POINTER(serpaout);
 }
 
 PG_FUNCTION_INFO_V1(pcpatch_pcid);

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -309,6 +309,10 @@ CREATE OR REPLACE FUNCTION PC_IsSorted(p pcpatch, attr text[], strict boolean de
 	RETURNS boolean AS 'MODULE_PATHNAME', 'pcpatch_is_sorted'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_Range(p pcpatch, first int4, count int4)
+	RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_range'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------

--- a/pgsql/sql/pointcloud.sql
+++ b/pgsql/sql/pointcloud.sql
@@ -232,6 +232,8 @@ SELECT PC_Envelope(pa) from pa_test;
 SELECT PC_AsText(PC_Union(pa)) FROM pa_test;
 SELECT sum(PC_NumPoints(pa)) FROM pa_test;
 
+SELECT PC_AsText(PC_Range(pa, 1, 1)) FROM pa_test;
+
 CREATE TABLE IF NOT EXISTS pa_test_dim (
     pa PCPATCH(3)
 );


### PR DESCRIPTION
This commit adds a `PC_Range` function. This function returns a patch of "count" points. These points are selected from the start-th point in the input patch.

Patch originally written by @pblottiere.