### PR TITLE
Use eclint 1.1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
   postgresql: "9.3" # for "installcheck"
 
 before_script:
-  - npm install -g eclint
+  - npm install -g eclint@1.1.5
   - eclint check * */* */cunit/*
   - ./autogen.sh
 


### PR DESCRIPTION
eclint 2 was recently released. Unfortunately this version is not compatible with the version of NodeJS available on Travis. So let's stick to eclint 1.1.5 for now.