### PR TITLE
Compile with -Werror on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - ./autogen.sh
 
 script:
-  - ./configure CFLAGS="-Wall -O2 -g" --with-lazperf=/usr/local/
+  - ./configure CFLAGS="-Wall -Werror -O2 -g" --with-lazperf=/usr/local/
   - make
   - make check
   - valgrind --leak-check=full --error-exitcode=1 lib/cunit/cu_tester


### PR DESCRIPTION
This PR adds `-Werror` to `CFLAGS` on Travis. This is to avoid merging code that introduces new compile warnings.