### PR TITLE
Make pointcloud_abs_out|in immutable and strict

### DIFF
--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -361,11 +361,11 @@ CREATE CAST (pcpoint AS pcpoint) WITH FUNCTION pcpoint(pcpoint, integer, boolean
 
 CREATE OR REPLACE FUNCTION pointcloud_abs_in(cstring)
 	RETURNS pointcloud_abs AS 'MODULE_PATHNAME'
-	LANGUAGE 'c';
+	LANGUAGE 'c' IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION pointcloud_abs_out(pointcloud_abs)
 	RETURNS cstring AS 'MODULE_PATHNAME'
-	LANGUAGE 'c';
+	LANGUAGE 'c' IMMUTABLE STRICT;
 
 CREATE TYPE pointcloud_abs (
 	internallength = 8,


### PR DESCRIPTION
Type I/O functions should not be volatile. PostgreSQL 9.5 and above include a test for this, yielding this warning when a volatile function is detected:

    WARNING:  type input function pointcloud_abs_in should not be volatile

This commit makes pointcloud_abs_out and pointcloud_abs_in, which are currently empty shells, non-volatile.

Fixes https://github.com/pgpointcloud/pointcloud/issues/93.