### PR TITLE
Add PC_SetPCId

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@
  - PC_IsSorted(pcpatch,text[],boolean) (#106)
  - PC_Range(pcpatch, int, int) returns pcpatch (#152)
  - PC_BoundingDiagonalAsBinary(pcpatch) and PC_BoundingDiagonal(pcpach) (#158)
+ - PC_SetPCId(pcpatch, int, float8 default 0.0) (#163)
 - Enhancements
  - Support sigbits encoding for 64bit integers (#61)
  - Warn about truncated values (#68)

--- a/README.md
+++ b/README.md
@@ -470,6 +470,12 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 
 > Returns a patch containing *n* points. These points are selected from the *start*-th point with 1-based indexing.
 
+**PC_SetPCId(p pcpatch, pcid int4, def float8 default 0.0)** returns **pcpatch**
+
+> Sets the schema on a PcPatch, given a valid `pcid` schema number.
+>
+> For dimensions that are in the "new" schema but not in the "old" schema the value `def` is set in the points of the output patch. `def` is optional, its default value is `0.0`.
+
 ### OGC "well-known binary" Functions
 
 **PC_AsBinary(p pcpoint)** returns **bytea**

--- a/lib/cunit/data/simple-schema-no-intensity.xml
+++ b/lib/cunit/data/simple-schema-no-intensity.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pc:PointCloudSchema xmlns:pc="http://pointcloud.org/schemas/PC/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <pc:dimension>
+    <pc:position>1</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description>X coordinate as a long integer. You must use the scale and offset information of the header to determine the double value.</pc:description>
+    <pc:name>X</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>2</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description>Y coordinate as a long integer. You must use the scale and offset information of the header to determine the double value.</pc:description>
+    <pc:name>Y</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>3</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description>Z coordinate as a long integer. You must use the scale and offset information of the header to determine the double value.</pc:description>
+    <pc:name>Z</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:metadata>
+    <Metadata name="compression">dimensional</Metadata>
+    <Metadata name="ght_xmin"></Metadata>
+    <Metadata name="ght_ymin"></Metadata>
+    <Metadata name="ght_xmax"></Metadata>
+    <Metadata name="ght_ymax"></Metadata>
+    <Metadata name="ght_keylength"></Metadata>
+    <Metadata name="ght_depth"></Metadata>
+    <Metadata name="spatialreference" type="id">4326</Metadata>
+  </pc:metadata>
+</pc:PointCloudSchema>

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -289,6 +289,8 @@ void pc_schema_set_dimension(PCSCHEMA *s, PCDIMENSION *d);
 void pc_schema_check_xyzm(PCSCHEMA *s);
 /** Get the width in bytes of a single point in the schema */
 size_t pc_schema_get_size(const PCSCHEMA *s);
+/** Check whether the schemas have the same dimensions at the same positions */
+uint32_t pc_schema_same_dimensions_and_positions(const PCSCHEMA *s1, const PCSCHEMA *s2);
 
 
 /**********************************************************************
@@ -478,5 +480,8 @@ uint32_t pc_patch_is_sorted(const PCPATCH *pa, const char **name, int ndims, cha
 
 /** Subset batch based on index */
 PCPATCH* pc_patch_range(const PCPATCH *pa, int first, int count);
+
+/** assign a schema to the patch */
+PCPATCH *pc_patch_set_schema(PCPATCH *patch, const PCSCHEMA *schema, double def);
 
 #endif /* _PC_API_H */

--- a/lib/pc_val.c
+++ b/lib/pc_val.c
@@ -218,5 +218,6 @@ pc_double_to_ptr(uint8_t *ptr, uint32_t interpretation, double val)
 		return PC_FAILURE;
 	}
 	}
+
 	return PC_SUCCESS;
 }

--- a/pgsql/CMakeLists.txt
+++ b/pgsql/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set ( PC_SOURCES
   pc_access.c 
+  pc_editor.c
   pc_inout.c      
   pc_pgsql.c       
   )

--- a/pgsql/Makefile
+++ b/pgsql/Makefile
@@ -5,6 +5,7 @@ include ../config.mk
 OBJS = \
 	pc_inout.o \
 	pc_access.o \
+	pc_editor.o \
 	pc_pgsql.o
 
 SED = sed

--- a/pgsql/expected/pointcloud.out
+++ b/pgsql/expected/pointcloud.out
@@ -95,6 +95,61 @@ VALUES (1, 0, -- XYZI, scaled, uncompressed
   </pc:metadata>
 </pc:PointCloudSchema>'
 )
+,(4, 0, -- (I1,X,Y,Z,I2), scaled, uncompressed
+'<?xml version="1.0" encoding="UTF-8"?>
+<pc:PointCloudSchema xmlns:pc="http://pointcloud.org/schemas/PC/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <pc:dimension>
+    <pc:position>1</pc:position>
+    <pc:size>2</pc:size>
+    <pc:description>The intensity value is the integer representation of the pulse return magnitude. This value is optional and system specific. However, it should always be included if available.</pc:description>
+    <pc:name>I1</pc:name>
+    <pc:interpretation>uint16_t</pc:interpretation>
+    <pc:scale>1</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>2</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description>X coordinate as a long integer. You must use the scale and offset information of the header to determine the double value.</pc:description>
+    <pc:name>X</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>3</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description>Y coordinate as a long integer. You must use the scale and offset information of the header to determine the double value.</pc:description>
+    <pc:name>Y</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>4</pc:position>
+    <pc:size>4</pc:size>
+    <pc:description>Z coordinate as a long integer. You must use the scale and offset information of the header to determine the double value.</pc:description>
+    <pc:name>Z</pc:name>
+    <pc:interpretation>int32_t</pc:interpretation>
+    <pc:scale>0.01</pc:scale>
+  </pc:dimension>
+  <pc:dimension>
+    <pc:position>5</pc:position>
+    <pc:size>2</pc:size>
+    <pc:description>The intensity value is the integer representation of the pulse return magnitude. This value is optional and system specific. However, it should always be included if available.</pc:description>
+    <pc:name>I2</pc:name>
+    <pc:interpretation>uint16_t</pc:interpretation>
+    <pc:scale>1</pc:scale>
+  </pc:dimension>
+  <pc:metadata>
+    <Metadata name="compression">none</Metadata>
+    <Metadata name="ght_xmin"></Metadata>
+    <Metadata name="ght_ymin"></Metadata>
+    <Metadata name="ght_xmax"></Metadata>
+    <Metadata name="ght_ymax"></Metadata>
+    <Metadata name="ght_keylength"></Metadata>
+    <Metadata name="ght_depth"></Metadata>
+    <Metadata name="spatialreference" type="id">4326</Metadata>
+  </pc:metadata>
+</pc:PointCloudSchema>'
+)
 ,(10, 0, -- All (signed) interpretations, uncompressed
 '<?xml version="1.0" encoding="UTF-8"?>
 <pc:PointCloudSchema xmlns:pc="http://pointcloud.org/schemas/PC/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -612,4 +667,47 @@ SELECT PC_BoundingDiagonalAsBinary(
  \x010200008002000000000000000000000000000000000000000000000000000000000000000000244000000000000024400000000000002440
 (1 row)
 
+-- test PC_SetPCId
+-- from pcid 1 to 1 (same dimensions, same positions, same compressions)
+-- pcid 1: (X,Y,Z,I), scaled, uncompressed
+SELECT
+  PC_AsText(PC_SetPCId(p, 1)) t, PC_Summary(PC_SetPCId(p, 1))::json->'compr' c
+FROM ( SELECT PC_Patch(PC_MakePoint(1, ARRAY[-1,0,4862413,1])) p ) foo;
+                    t                    |   c    
+-----------------------------------------+--------
+ {"pcid":1,"pts":[[-1,0,4.86241e+06,1]]} | "none"
+(1 row)
+
+-- test PC_SetPCId
+-- from pcid 1 to 3 (same dimensions, same positions, different compressions)
+-- pcid 1: (X,Y,Z,I), scaled, uncompressed
+-- pcid 3: (X,Y,Z,I), scaled, dimensionally compressed
+SELECT
+  PC_AsText(PC_SetPCId(p, 3)) t, PC_Summary(PC_SetPCId(p, 3))::json->'compr' c
+FROM ( SELECT PC_Patch(PC_MakePoint(1, ARRAY[-1,0,4862413,1])) p ) foo;
+                    t                    |       c       
+-----------------------------------------+---------------
+ {"pcid":3,"pts":[[-1,0,4.86241e+06,1]]} | "dimensional"
+(1 row)
+
+-- test PC_SetPCId
+-- from pcid 1 to 4 (different dimensions, different positions, same compressions)
+-- pcid 1: (X,Y,Z,I), scaled, uncompressed
+-- pcid 2: (I1,X,Y,Z,I2), scaled, uncompressed
+SELECT
+  PC_AsText(PC_SetPCId(p, 4, 2.0)) t, PC_Summary(PC_SetPCId(p, 4, 2.0))::json->'compr' c
+FROM ( SELECT PC_Patch(PC_MakePoint(1, ARRAY[-1,0,4862413,1])) p ) foo;
+                     t                     |   c    
+-------------------------------------------+--------
+ {"pcid":4,"pts":[[2,-1,0,4.86241e+06,2]]} | "none"
+(1 row)
+
+-- test PC_SetPCId
+-- from pcid 1 to 10 (incompatible dimensions because of different interpretations)
+-- pcid 1: (X,Y,Z,I), scaled, uncompressed
+-- pcid 10: (X,Y,Z), unscaled, dimensionally compressed
+SELECT
+  PC_AsText(PC_SetPCId(p, 10)) t, PC_Summary(PC_SetPCId(p, 10))::json->'compr' c
+FROM ( SELECT PC_Patch(PC_MakePoint(1, ARRAY[-1,0,4862413,1])) p ) foo;
+ERROR:  dimension interpretations are not matching
 TRUNCATE pointcloud_formats;

--- a/pgsql/pc_editor.c
+++ b/pgsql/pc_editor.c
@@ -1,0 +1,94 @@
+/***********************************************************************
+* pc_editor.c
+*
+*  Editor functions for points and patches in PgSQL.
+*
+*  Copyright (c) 2017 Oslandia
+*
+***********************************************************************/
+
+#include "pc_pgsql.h"	   /* Common PgSQL support for our type */
+
+Datum pcpatch_setpcid(PG_FUNCTION_ARGS);
+
+
+static bool
+pcpatch_schema_same_dimensions(const PCSCHEMA *s1, const PCSCHEMA *s2)
+{
+	size_t i;
+
+	if ( s1->ndims != s2->ndims )
+		return false;
+
+	for ( i = 0; i < s1->ndims; i++ )
+	{
+		PCDIMENSION *s1dim = s1->dims[i];
+		PCDIMENSION *s2dim = s2->dims[i];
+
+		if ( strcmp(s1dim->name, s2dim->name) != 0 )
+			return false;
+
+		if ( s1dim->interpretation != s2dim->interpretation )
+			return false;
+	}
+
+	return true;
+}
+
+
+PG_FUNCTION_INFO_V1(pcpatch_setpcid);
+Datum pcpatch_setpcid(PG_FUNCTION_ARGS)
+{
+	PCPATCH *paout = NULL;
+	SERIALIZED_PATCH *serpatch;
+	SERIALIZED_PATCH *serpa = PG_GETARG_SERPATCH_P(0);
+	int32 pcid = PG_GETARG_INT32(1);
+	float8 def = PG_GETARG_FLOAT8(2);
+	PCSCHEMA *old_schema = pc_schema_from_pcid(serpa->pcid, fcinfo);
+	PCSCHEMA *new_schema = pc_schema_from_pcid(pcid, fcinfo);
+
+	if ( pcpatch_schema_same_dimensions(old_schema, new_schema) )
+	{
+		// old_schema and new_schema have the same dimensions at the same
+		// positions, so we can take a fast path avoid the point-by-point,
+		// dimension-by-dimension copying
+
+		if ( old_schema->compression == new_schema->compression )
+		{
+			// no need to deserialize the patch
+			serpatch = palloc(serpa->size);
+			if ( ! serpatch )
+				PG_RETURN_NULL();
+			memcpy(serpatch, serpa, serpa->size);
+			serpatch->pcid = pcid;
+			PG_RETURN_POINTER(serpatch);
+		}
+		else
+		{
+			paout = pc_patch_deserialize(serpa, old_schema);
+			if ( ! paout )
+				PG_RETURN_NULL();
+			paout->schema = new_schema;
+		}
+	} else {
+		PCPATCH *patch;
+
+		patch = pc_patch_deserialize(serpa, old_schema);
+		if ( ! patch )
+			PG_RETURN_NULL();
+
+		paout = pc_patch_set_schema(patch, new_schema, def);
+
+		if ( patch != paout )
+			pc_patch_free(patch);
+
+		if ( ! paout )
+			PG_RETURN_NULL();
+
+	}
+
+	serpatch = pc_patch_serialize(paout, NULL);
+	pc_patch_free(paout);
+
+	PG_RETURN_POINTER(serpatch);
+}

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -317,6 +317,10 @@ CREATE OR REPLACE FUNCTION PC_BoundingDiagonalAsBinary(p pcpatch)
 	RETURNS bytea AS 'MODULE_PATHNAME', 'pcpatch_bounding_diagonal_as_bytea'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION PC_SetPCId(p pcpatch, pcid int4, def float8 default 0.0)
+	RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_setpcid'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
 -------------------------------------------------------------------
 --  POINTCLOUD_COLUMNS
 -------------------------------------------------------------------


### PR DESCRIPTION
This PR is a clean version of https://github.com/pgpointcloud/pointcloud/pull/154, taking into account all the review comments and with one squashed commits instead of 19.

Commit message:

Add PC_SetPCId

This commit adds a `PC_SetPCId` function that can be used to change the schema of a patch.