### PR TITLE
Add the geometry(pcpach) function back

### DIFF
--- a/pgsql_postgis/pointcloud_postgis--1.0.sql
+++ b/pgsql_postgis/pointcloud_postgis--1.0.sql
@@ -23,7 +23,15 @@ CREATE OR REPLACE FUNCTION PC_Envelope(pcpatch)
 	$$
 	LANGUAGE 'sql';
 
+CREATE OR REPLACE FUNCTION geometry(pcpatch)
+	RETURNS geometry AS
+	$$
+		SELECT PC_Envelope($1)
+	$$
+	LANGUAGE 'sql';
+
 CREATE CAST (pcpatch AS geometry) WITH FUNCTION PC_Envelope(pcpatch);
+
 
 -----------------------------------------------------------------------------
 -- Cast from pcpoint to point


### PR DESCRIPTION
For backward-compatibility reasons this commit adds back the `geometry(pcpatch)` function that was removed with 7da35f0. This function is just an alias to `PC_Envelope(pcpatch)`.