### PR TITLE
Ignore case where comparing dimension names

### DIFF
--- a/pgsql/pc_editor.c
+++ b/pgsql/pc_editor.c
@@ -25,7 +25,7 @@ pcpatch_schema_same_dimensions(const PCSCHEMA *s1, const PCSCHEMA *s2)
 		PCDIMENSION *s1dim = s1->dims[i];
 		PCDIMENSION *s2dim = s2->dims[i];
 
-		if ( strcmp(s1dim->name, s2dim->name) != 0 )
+		if ( strcasecmp(s1dim->name, s2dim->name) != 0 )
 			return false;
 
 		if ( s1dim->interpretation != s2dim->interpretation )


### PR DESCRIPTION
The case of the characters should be ignored when comparing dimension names in pcpatch_schema_same_dimensions. This is to match the behavior of pc_schema_get_dimension_by_name which ignores the case.