### PR TITLE
Add PC_Envelope back to the pointcloud extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ Now that you have created two tables, you'll see entries for them in the `pointc
 >     14ae4781464090c2f5285cbf5fc0ec51b81e858b46400ad7
 >     a3703dba5fc0ec51b81e858b46400ad7a3703dba5fc0e17a
 >     14ae4781464090c2f5285cbf5fc0e17a14ae47814640
+>
+> **PC_Envelope** is an alias to **PC_EnvelopeBinary**. But **PC_Envelope** is deprecated and will be removed in a future version (2.0) of the extension. **PC_EnvelopeAsBinary** is to be used instead.
 
 **PC_BoundingDiagonalAsBinary(p pcpatch)** returns **bytea**
 
@@ -564,20 +566,20 @@ The `pointcloud_postgis` extension adds functions that allow you to use PostgreS
 > 
 >     POINT Z (-127 45 124)
 
-**PC_Envelope(pcpatch)** returns **geometry**
+**PC_EnvelopeGeometry(pcpatch)** returns **geometry**
 
 > Returns the 2D *bounds* of the patch as a PostGIS Polygon 2D.
 > Useful for performing 2D intersection tests with PostGIS geometries.
 >
->     SELECT ST_AsText(PC_Envelope(pa)) FROM patches LIMIT 1;
+>     SELECT ST_AsText(PC_EnvelopeGeometry(pa)) FROM patches LIMIT 1;
 >
 >     POLYGON((-126.99 45.01,-126.99 45.09,-126.91 45.09,-126.91 45.01,-126.99 45.01))
 
-**PC_BoundingDiagonal(pcpatch)** returns **geometry**
+**PC_BoundingDiagonalGeometry(pcpatch)** returns **geometry**
 
 > Returns the bounding diagonal of a patch. This is a LineString (2D), a LineString Z or a LineString M or a LineString ZM, based on the existence of the Z and M dimensions in the patch. This function is useful for creating an index on a patch column.
 >
->     SELECT ST_AsText(PC_BoundingDiagonal(pa)) FROM patches;
+>     SELECT ST_AsText(PC_BoundingDiagonalGeometry(pa)) FROM patches;
 >                       st_astext
 >    ------------------------------------------------
 >     LINESTRING Z (-126.99 45.01 1,-126.91 45.09 9)

--- a/pgsql/expected/pointcloud.out
+++ b/pgsql/expected/pointcloud.out
@@ -355,6 +355,15 @@ SELECT PC_EnvelopeAsBinary(pa) from pa_test;
  \x01030000000100000005000000b81e85eb51b8ae3fec51b81e85ebb13fb81e85eb51b8ae3f9a9999999999b93f0ad7a3703d0ab73f9a9999999999b93f0ad7a3703d0ab73fec51b81e85ebb13fb81e85eb51b8ae3fec51b81e85ebb13f
 (4 rows)
 
+SELECT PC_Envelope(pa) from pa_test;
+                                                                                         pc_envelope                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ \x010300000001000000050000007b14ae47e17a943fb81e85eb51b89e3f7b14ae47e17a943fb81e85eb51b89e3f7b14ae47e17a943fb81e85eb51b89e3f7b14ae47e17a943fb81e85eb51b89e3f7b14ae47e17a943fb81e85eb51b89e3f
+ \x01030000000100000005000000b81e85eb51b8ae3fec51b81e85ebb13fb81e85eb51b8ae3f9a9999999999b93f0ad7a3703d0ab73f9a9999999999b93f0ad7a3703d0ab73fec51b81e85ebb13fb81e85eb51b8ae3fec51b81e85ebb13f
+ \x01030000000100000005000000b81e85eb51b8ae3fec51b81e85ebb13fb81e85eb51b8ae3f9a9999999999b93f0ad7a3703d0ab73f9a9999999999b93f0ad7a3703d0ab73fec51b81e85ebb13fb81e85eb51b8ae3fec51b81e85ebb13f
+ \x01030000000100000005000000b81e85eb51b8ae3fec51b81e85ebb13fb81e85eb51b8ae3f9a9999999999b93f0ad7a3703d0ab73f9a9999999999b93f0ad7a3703d0ab73fec51b81e85ebb13fb81e85eb51b8ae3fec51b81e85ebb13f
+(4 rows)
+
 SELECT PC_AsText(PC_Union(pa)) FROM pa_test;
                                                                                  pc_astext                                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/pgsql/pc_inout.c
+++ b/pgsql/pc_inout.c
@@ -31,7 +31,7 @@ Datum pcpoint_from_double_array(PG_FUNCTION_ARGS);
 Datum pcpoint_as_text(PG_FUNCTION_ARGS);
 Datum pcpatch_as_text(PG_FUNCTION_ARGS);
 Datum pcpoint_as_bytea(PG_FUNCTION_ARGS);
-Datum pcpatch_bytea_envelope(PG_FUNCTION_ARGS);
+Datum pcpatch_envelope_as_bytea(PG_FUNCTION_ARGS);
 Datum pcpatch_bounding_diagonal_as_bytea(PG_FUNCTION_ARGS);
 
 

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -198,6 +198,12 @@ CREATE OR REPLACE FUNCTION PC_EnvelopeAsBinary(p pcpatch)
 	RETURNS bytea AS 'MODULE_PATHNAME', 'pcpatch_envelope_as_bytea'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
+-- PC_Envelope is an alias to PC_EnvelopeAsBinary, it is kept for
+-- backward-compatibility
+CREATE OR REPLACE FUNCTION PC_Envelope(p pcpatch)
+	RETURNS bytea AS 'MODULE_PATHNAME', 'pcpatch_envelope_as_bytea'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
 CREATE OR REPLACE FUNCTION PC_Uncompress(p pcpatch)
 	RETURNS pcpatch AS 'MODULE_PATHNAME', 'pcpatch_uncompress'
 	LANGUAGE 'c' IMMUTABLE STRICT;

--- a/pgsql/sql/pointcloud.sql
+++ b/pgsql/sql/pointcloud.sql
@@ -284,6 +284,7 @@ SELECT PC_Uncompress(pa) FROM pa_test LIMIT 1;
 
 SELECT PC_AsText(pa) FROM pa_test;
 SELECT PC_EnvelopeAsBinary(pa) from pa_test;
+SELECT PC_Envelope(pa) from pa_test;
 SELECT PC_AsText(PC_Union(pa)) FROM pa_test;
 SELECT sum(PC_NumPoints(pa)) FROM pa_test;
 

--- a/pgsql_postgis/pointcloud_postgis--1.0.sql
+++ b/pgsql_postgis/pointcloud_postgis--1.0.sql
@@ -16,7 +16,7 @@ CREATE OR REPLACE FUNCTION PC_Intersection(pcpatch, geometry)
 -----------------------------------------------------------------------------
 -- Cast from pcpatch to polygon
 --
-CREATE OR REPLACE FUNCTION PC_Envelope(pcpatch)
+CREATE OR REPLACE FUNCTION PC_EnvelopeGeometry(pcpatch)
 	RETURNS geometry AS
 	$$
 		SELECT ST_GeomFromEWKB(PC_EnvelopeAsBinary($1))
@@ -26,11 +26,11 @@ CREATE OR REPLACE FUNCTION PC_Envelope(pcpatch)
 CREATE OR REPLACE FUNCTION geometry(pcpatch)
 	RETURNS geometry AS
 	$$
-		SELECT PC_Envelope($1)
+		SELECT PC_EnvelopeGeometry($1)
 	$$
 	LANGUAGE 'sql';
 
-CREATE CAST (pcpatch AS geometry) WITH FUNCTION PC_Envelope(pcpatch);
+CREATE CAST (pcpatch AS geometry) WITH FUNCTION PC_EnvelopeGeometry(pcpatch);
 
 
 -----------------------------------------------------------------------------
@@ -52,7 +52,7 @@ CREATE CAST (pcpoint AS geometry) WITH FUNCTION geometry(pcpoint);
 CREATE OR REPLACE FUNCTION PC_Intersects(pcpatch, geometry)
 	RETURNS boolean AS
 	$$
-		SELECT ST_Intersects($2, PC_Envelope($1))
+		SELECT ST_Intersects($2, PC_EnvelopeGeometry($1))
 	$$
 	LANGUAGE 'sql';
 
@@ -66,7 +66,7 @@ CREATE OR REPLACE FUNCTION PC_Intersects(geometry, pcpatch)
 -----------------------------------------------------------------------------
 -- Function from pcpatch to LineString
 --
-CREATE OR REPLACE FUNCTION PC_BoundingDiagonal(pcpatch)
+CREATE OR REPLACE FUNCTION PC_BoundingDiagonalGeometry(pcpatch)
 	RETURNS geometry AS
 	$$
 		SELECT ST_GeomFromEWKB(PC_BoundingDiagonalAsBinary($1))


### PR DESCRIPTION
This commits adds `PC_Envelope` back to the pointcloud extension. This is to address the backward-compatibility issue raised in #168.