### PR TITLE
Fix compilation with libght

### DIFF
--- a/lib/cunit/cu_pc_patch.c
+++ b/lib/cunit/cu_pc_patch.c
@@ -1200,7 +1200,7 @@ test_patch_set_schema_compression_ght()
 	pcfree(str);
 
 	// assign a schema with unknown dimension to the patch
-	pat1 = pc_patch_set_schema(pat0, simpleschema, 1, 0.0);
+	pat1 = pc_patch_set_schema(pat0, simpleschema, 0.0);
 	CU_ASSERT(pat1 != NULL);
 	str = pc_patch_to_string(pat1);
 	CU_ASSERT_STRING_EQUAL(str, "{\"pcid\":0,\"pts\":[[0.4,0.8,1.2,0],[0.3,0.6,0.9,0],[0.2,0.4,0.6,0],[0.1,0.2,0.3,0],[0,0,0,0]]}");

--- a/lib/pc_patch_ght.c
+++ b/lib/pc_patch_ght.c
@@ -132,8 +132,8 @@ pc_patch_ght_from_uncompressed(const PCPATCH_UNCOMPRESSED *pa)
 	pt.schema = pa->schema;
 	pt.readonly = PC_TRUE;
 
-	xdim = pa->schema->dims[pa->schema->x_position];
-	ydim = pa->schema->dims[pa->schema->y_position];
+	xdim = pa->schema->xdim;
+	ydim = pa->schema->ydim;
 
 	schema = ght_schema_from_pc_schema(pa->schema);
 	if ( ght_tree_new(schema, &tree) != GHT_OK ) {
@@ -162,11 +162,12 @@ pc_patch_ght_from_uncompressed(const PCPATCH_UNCOMPRESSED *pa)
 				GhtAttributePtr attr;
 				double val;
 
+				dim = pc_schema_get_dimension(pa->schema, j);
+
 				/* Don't add X or Y as attributes, they are already embodied in the hash */
-				if ( j == pa->schema->x_position || j == pa->schema->y_position )
+				if ( dim == pa->schema->xdim || dim == pa->schema->ydim )
 					continue;
 
-				dim = pc_schema_get_dimension(pa->schema, j);
 				pc_point_get_double(&pt, dim, &val);
 
 				ght_schema_get_dimension_by_index(schema, j, &ghtdim);


### PR DESCRIPTION
This PR fixes compilations errors in the pointcloud ght code. We don't builld with libght enabled on Travis, so we do not always see errors.

Fixes #175.