### PR TITLE
Build and test with libght in Travis

### DIFF
--- a/.install-libght.sh
+++ b/.install-libght.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -ex
+git clone https://github.com/pramsey/libght.git
+cd libght; cmake .; make; sudo make install; sudo ldconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,19 @@ install:
   - sudo apt-get install -qq g++-4.8
   - export CXX="g++-4.8"
   - sh .install-lazperf.sh
+  - sh .install-libght.sh
+  - npm install -g eclint@1.1.5
 
 addons:
   postgresql: "9.3" # for "installcheck"
 
-before_script:
-  - npm install -g eclint@1.1.5
-  - eclint check * */* */cunit/*
-  - ./autogen.sh
+# Note: Valgrind currently reports many problems when libght is enabled. So for
+# now, and until the problems are fixed, we just run the unit tests with libght
+# enabled.
 
 script:
-  - ./configure CFLAGS="-Wall -Werror -O2 -g" --with-lazperf=/usr/local/
-  - make
-  - make check
-  - valgrind --leak-check=full --error-exitcode=1 lib/cunit/cu_tester
-  - sudo make install
+  - eclint check * */* */cunit/*
+  - ./tools/build-install.sh --with-lazperf=/usr/local --with-libght=/usr/local && make check
+  - ./tools/build-install.sh --with-lazperf=/usr/local --without-libght && ./tools/valgrind.sh
   - make installcheck || { cat pgsql/regression.diffs && false; }
-  - cd tools/benchmark_compression && sh compression_benchmark.sh
+  - (cd tools/benchmark_compression && sh compression_benchmark.sh)

--- a/tools/build-install.sh
+++ b/tools/build-install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [[ -f config.mk ]]; then
+    make clean maintainer-clean
+fi
+
+./autogen.sh
+./configure CFLAGS="-Wall -Werror -O2 -g" $@
+make
+sudo make install

--- a/tools/valgrind.sh
+++ b/tools/valgrind.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+valgrind --leak-check=full --error-exitcode=1 lib/cunit/cu_tester


### PR DESCRIPTION
#175 has reported that we've broken the build when libght is enabled. The problem is that we don't currently build with libght enabled on Travis. This PR is a resurrection of #134 and suggests to build and run unit tests with libght enabled on Travis.

Depends on #176, which should be merged first.