### PR TITLE
Add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
     && git clone https://github.com/pgpointcloud/pointcloud \
     && cd pointcloud \
     && ./autogen.sh \
-    && ./configure CFLAGS="-Wall -Werror -O2 -g" \
+    && ./configure --with-pgconfig=/usr/lib/postgresql/${POSTGRES_VERSION}/bin/pg_config CFLAGS="-Wall -Werror -O2 -g" \
     && make \
     && make install \
     && apt-get purge -y --auto-remove \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM postgres:9.6
+
+ENV POSTGRES_VERSION 9.6
+ENV POSTGIS_VERSION 2.3
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        postgis \
+        postgresql-${POSTGRES_VERSION}-postgis-${POSTGIS_VERSION} \
+        postgresql-${POSTGRES_VERSION}-postgis-${POSTGIS_VERSION}-scripts
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        build-essential \
+        autoconf \
+        automake \
+        zlib1g-dev \
+        postgresql-server-dev-all \
+        libxml2-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && git clone https://github.com/pgpointcloud/pointcloud \
+    && cd pointcloud \
+    && ./autogen.sh \
+    && ./configure CFLAGS="-Wall -Werror -O2 -g" \
+    && make \
+    && make install \
+    && apt-get purge -y --auto-remove \
+        git \
+        ca-certificates \
+        build-essential \
+        autoconf \
+        automake \
+        zlib1g-dev \
+        postgresql-server-dev-all \
+        libxml2-dev


### PR DESCRIPTION
This PR adds a Dockerfile. The built image is based on the [official postgres 9.6 image](https://hub.docker.com/_/postgres/).

The goal of this Docker image is to make it easy for people to install and try out the Pointcloud extension.

Fixes #178.