### PR TITLE
Make hexbytes_from_bytes perform better

### DIFF
--- a/lib/cunit/cu_pc_patch.c
+++ b/lib/cunit/cu_pc_patch.c
@@ -139,7 +139,7 @@ test_patch_hex_in()
 	double d;
 	char *str;
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	PCPATCH *pa = pc_patch_from_wkb(simpleschema, wkb, hexsize/2);
 	PCPOINTLIST *pl = pc_pointlist_from_patch(pa);
 
@@ -203,7 +203,7 @@ test_patch_hex_out()
 	pa = pc_patch_uncompressed_from_pointlist(pl);
 	wkb = pc_patch_uncompressed_to_wkb(pa, &wkbsize);
 	// printf("wkbsize %zu\n", wkbsize);
-	hexwkb = hexbytes_from_bytes(wkb, wkbsize);
+	hexwkb = pc_hexbytes_from_bytes(wkb, wkbsize);
 
 	// printf("hexwkb %s\n", hexwkb);
 	// printf("hexresult_ndr %s\n", hexresult_ndr);
@@ -240,7 +240,7 @@ test_schema_xy()
 	*/
 	static char *hexpt = "01010000000AE9C90307A1100522A5000019000101010001067C9F1C4953C474650A0E412700390038001400000000000000876B6601962F750155320000";
 
-	uint8_t *bytes =  bytes_from_hexbytes(hexpt, strlen(hexpt));
+	uint8_t *bytes =  pc_bytes_from_hexbytes(hexpt, strlen(hexpt));
 	PCPOINT *pt;
 	double val;
 
@@ -479,7 +479,7 @@ test_patch_wkb()
 
 	pa1 = (PCPATCH*)pc_patch_dimensional_from_pointlist(pl1);
 	wkb1 = pc_patch_to_wkb(pa1, &z1);
-	// str = hexbytes_from_bytes(wkb1, z1);
+	// str = pc_hexbytes_from_bytes(wkb1, z1);
 	// printf("str\n%s\n",str);
 	pa2 = pc_patch_from_wkb(simpleschema, wkb1, z1);
 
@@ -617,7 +617,7 @@ test_patch_pointn_last_first()
 
 	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	char *str;
 
 	PCPATCH *pa = pc_patch_from_wkb(simpleschema, wkb, hexsize/2);
@@ -651,7 +651,7 @@ test_patch_pointn_no_compression()
 
 	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 
 	PCPATCH *pa = pc_patch_from_wkb(simpleschema, wkb, hexsize/2);
 	PCPOINTLIST *li = pc_pointlist_from_patch(pa);
@@ -753,7 +753,7 @@ test_patch_pointn_ght_compression()
 
 	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 
 	PCPATCH *pa = pc_patch_from_wkb(simpleschema, wkb, hexsize/2);
 	PCPOINTLIST *li = pc_pointlist_from_patch(pa);
@@ -787,7 +787,7 @@ test_patch_pointn_laz_compression()
 
 	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	char *str;
 
 	PCPATCH *pa = pc_patch_from_wkb(simpleschema, wkb, hexsize/2);
@@ -1332,7 +1332,7 @@ test_patch_transform_compression_none()
 	// expected: x=hex(20)=0x14, y=hex(40)=0x28, z=hex(60)=0x3C, I=hex(10)=0x0A
 	pt = pc_patch_pointn(pa, 1);
 	wkb = pc_point_to_wkb(pt, &wkbsize);
-	str = hexbytes_from_bytes(wkb, wkbsize);
+	str = pc_hexbytes_from_bytes(wkb, wkbsize);
 	CU_ASSERT_STRING_EQUAL(str, "010000000014000000280000003C0000000A00");
 	pcfree(str);
 	pcfree(wkb);
@@ -1342,7 +1342,7 @@ test_patch_transform_compression_none()
 	// expected: x=hex(15)=0x0F, y=hex(30)=0x1E, z=hex(45)=0x2D, I=hex(10)=0x0A
 	pt = pc_patch_pointn(pa, 2);
 	wkb = pc_point_to_wkb(pt, &wkbsize);
-	str = hexbytes_from_bytes(wkb, wkbsize);
+	str = pc_hexbytes_from_bytes(wkb, wkbsize);
 	CU_ASSERT_STRING_EQUAL(str, "01000000000F0000001E0000002D0000000A00");
 	pcfree(str);
 	pcfree(wkb);
@@ -1352,7 +1352,7 @@ test_patch_transform_compression_none()
 	// expected: x=hex(10)=0x0A, y=hex(20)=0x14, z=hex(30)=0x1E, I=hex(10)=0x0A
 	pt = pc_patch_pointn(pa, 3);
 	wkb = pc_point_to_wkb(pt, &wkbsize);
-	str = hexbytes_from_bytes(wkb, wkbsize);
+	str = pc_hexbytes_from_bytes(wkb, wkbsize);
 	CU_ASSERT_STRING_EQUAL(str, "01000000000A000000140000001E0000000A00");
 	pcfree(str);
 	pcfree(wkb);
@@ -1362,7 +1362,7 @@ test_patch_transform_compression_none()
 	// expected: x=hex(5)=0x05, y=hex(10)=0x0A, z=hex(15)=0x0F, I=hex(10)=0x0A
 	pt = pc_patch_pointn(pa, 4);
 	wkb = pc_point_to_wkb(pt, &wkbsize);
-	str = hexbytes_from_bytes(wkb, wkbsize);
+	str = pc_hexbytes_from_bytes(wkb, wkbsize);
 	CU_ASSERT_STRING_EQUAL(str, "0100000000050000000A0000000F0000000A00");
 	pcfree(str);
 	pcfree(wkb);
@@ -1372,7 +1372,7 @@ test_patch_transform_compression_none()
 	// expected: x=hex(0)=0x00, y=hex(0)=0x00, z=hex(0)=0x00, I=hex(10)=0x0A
 	pt = pc_patch_pointn(pa, 5);
 	wkb = pc_point_to_wkb(pt, &wkbsize);
-	str = hexbytes_from_bytes(wkb, wkbsize);
+	str = pc_hexbytes_from_bytes(wkb, wkbsize);
 	CU_ASSERT_STRING_EQUAL(str, "01000000000000000000000000000000000A00");
 	pcfree(str);
 	pcfree(wkb);

--- a/lib/cunit/cu_pc_point.c
+++ b/lib/cunit/cu_pc_point.c
@@ -86,7 +86,7 @@ test_point_hex_inout()
 	double d;
 	char *hexbuf = "00000000010000000100000002000000030004";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	PCPOINT *pt = pc_point_from_wkb(schema, wkb, hexsize/2);
 	CU_ASSERT_SUCCESS(pc_point_get_double_by_name(pt, "X", &d));
 	CU_ASSERT_DOUBLE_EQUAL(d, 0.01, 0.000001);
@@ -102,7 +102,7 @@ test_point_hex_inout()
 
 	hexbuf = "01010000000100000002000000030000000500";
 	hexsize = strlen(hexbuf);
-	wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	pt = pc_point_from_wkb(schema, wkb, hexsize/2);
 	CU_ASSERT_SUCCESS(pc_point_get_double_by_name(pt, "X", &d));
 	CU_ASSERT_DOUBLE_EQUAL(d, 0.01, 0.000001);
@@ -275,12 +275,12 @@ void test_point_geometry_bytes(const PCSCHEMA *s, size_t expectedgeomwkbsize,
 	size_t pthexsize, geomwkbsize;
 
 	pthexsize = strlen(pthexbytes);
-	ptwkb = bytes_from_hexbytes(pthexbytes, pthexsize);
+	ptwkb = pc_bytes_from_hexbytes(pthexbytes, pthexsize);
 	pt = pc_point_from_wkb(s, ptwkb, pthexsize/2);
 	CU_ASSERT_PTR_NOT_NULL(pt);
 	geomwkb = pc_point_to_geometry_wkb(pt, &geomwkbsize);
 	CU_ASSERT_EQUAL(geomwkbsize,expectedgeomwkbsize);
-	geomhexbytes = hexbytes_from_bytes(geomwkb,geomwkbsize);
+	geomhexbytes = pc_hexbytes_from_bytes(geomwkb,geomwkbsize);
 	CU_ASSERT_STRING_EQUAL(geomhexbytes, expectedgeomhexbytes);
 
 	pcfree(geomhexbytes);

--- a/lib/cunit/cu_pc_sort.c
+++ b/lib/cunit/cu_pc_sort.c
@@ -58,7 +58,7 @@ test_sort_simple()
 	char *hexbuf = "0000000000000000000000000200000008000000030000000500060000000200000001000000040008";
 	size_t hexsize = strlen(hexbuf);
 
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
 	PCPOINTLIST *li = pc_pointlist_from_patch(pa);
 	const char *X[] = {"X"};
@@ -104,7 +104,7 @@ test_sort_consistency()
 	uint8_t *wkbsort;
 	char *hexbuf = "0000000000000000000000000200000008000000030000000500060000000200000001000000040008";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
 	PCPOINTLIST *li = pc_pointlist_from_patch(pa);
 	const char *X[] = {"X"};
@@ -114,7 +114,7 @@ test_sort_consistency()
 
 	//chek consistency
 	wkbsort = pc_patch_to_wkb(pasort, &hexsize);
-	CU_ASSERT_EQUAL(wkb_get_pcid(wkb), wkb_get_pcid(wkbsort));
+	CU_ASSERT_EQUAL(pc_wkb_get_pcid(wkb), pc_wkb_get_pcid(wkbsort));
 	CU_ASSERT_EQUAL(wkb_get_npoints(wkb), wkb_get_npoints(wkbsort));
 	CU_ASSERT_EQUAL(wkb_get_compression(wkb), wkb_get_compression(wkbsort));
 
@@ -149,7 +149,7 @@ test_sort_one_point()
 	uint8_t *wkbsort;
 	char *hexbuf = "000000000000000000000000010000000200000003000000050006";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
 	PCPOINTLIST *li = pc_pointlist_from_patch(pa);
 	const char *X[] = {"X"};
@@ -159,7 +159,7 @@ test_sort_one_point()
 
 	// check consistency
 	wkbsort = pc_patch_to_wkb(pasort, &hexsize);
-	CU_ASSERT_EQUAL(wkb_get_pcid(wkb), wkb_get_pcid(wkbsort));
+	CU_ASSERT_EQUAL(pc_wkb_get_pcid(wkb), pc_wkb_get_pcid(wkbsort));
 	CU_ASSERT_EQUAL(wkb_get_npoints(wkb), wkb_get_npoints(wkbsort));
 	CU_ASSERT_EQUAL(wkb_get_compression(wkb), wkb_get_compression(wkbsort));
 
@@ -192,7 +192,7 @@ test_sort_stable()
 	PCPATCH *pasort;
 	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
 	PCPOINTLIST *li = pc_pointlist_from_patch(pa);
 	const char *dims[] = {"Y"};
@@ -229,7 +229,7 @@ test_sort_patch_is_sorted_no_compression()
 	PCPATCH *pasort;
 	char *hexbuf = "00000000000000000000000003000000080000000300000005000600000002000000030000000400080000000200000003000000040009";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
 	PCPOINTLIST *li = pc_pointlist_from_patch(pa);
 	const char *X[] = {"X"};
@@ -341,7 +341,7 @@ test_sort_patch_ndims()
 	PCPATCH *pasort1, *pasort2;
 	char *hexbuf = "00000000000000000000000003000000080000000400000005000600000002000000030000000400080000000200000002000000040009";
 	size_t hexsize = strlen(hexbuf);
-	uint8_t *wkb = bytes_from_hexbytes(hexbuf, hexsize);
+	uint8_t *wkb = pc_bytes_from_hexbytes(hexbuf, hexsize);
 	PCPATCH *pa = pc_patch_from_wkb(schema, wkb, hexsize/2);
 	const char *X[] = {"X"};
 	const char *Y[] = {"Y"};

--- a/lib/cunit/cu_pc_util.c
+++ b/lib/cunit/cu_pc_util.c
@@ -55,7 +55,7 @@ test_bounding_diagonal_wkb_from_bounds()
 	CU_ASSERT(wkb != NULL);
 	CU_ASSERT(wkbsize == 41);
 
-	wkbhex = hexbytes_from_bytes(wkb, wkbsize);
+	wkbhex = pc_hexbytes_from_bytes(wkb, wkbsize);
 	CU_ASSERT(wkbhex != NULL);
 	CU_ASSERT_STRING_EQUAL(wkbhex, "01020000000200000000000000000024C000000000000024C000000000000024400000000000002440");
 
@@ -84,7 +84,7 @@ test_bounding_diagonal_wkb_from_stats()
 	CU_ASSERT(wkb != NULL);
 	CU_ASSERT(wkbsize == 73);
 
-	wkbhex = hexbytes_from_bytes(wkb, wkbsize);
+	wkbhex = pc_hexbytes_from_bytes(wkb, wkbsize);
 	CU_ASSERT(wkbhex != NULL);
 	CU_ASSERT_STRING_EQUAL(wkbhex, "01020000C00200000000000000000024C000000000000024C000000000000024C000000000000000000000000000002440000000000000244000000000000024400000000000000000");
 

--- a/lib/pc_api.h
+++ b/lib/pc_api.h
@@ -253,11 +253,11 @@ void pc_install_default_handlers(void);
 */
 
 /** Convert binary to hex */
-uint8_t* bytes_from_hexbytes(const char *hexbuf, size_t hexsize);
+uint8_t* pc_bytes_from_hexbytes(const char *hexbuf, size_t hexsize);
 /** Convert hex to binary */
-char* hexbytes_from_bytes(const uint8_t *bytebuf, size_t bytesize);
+char* pc_hexbytes_from_bytes(const uint8_t *bytebuf, size_t bytesize);
 /** Read the the PCID from WKB form of a POINT/PATCH */
-uint32_t wkb_get_pcid(const uint8_t *wkb);
+uint32_t pc_wkb_get_pcid(const uint8_t *wkb);
 /** Build an empty #PCDIMSTATS based on the schema */
 PCDIMSTATS* pc_dimstats_make(const PCSCHEMA *schema);
 /** Get compression name from enum */

--- a/lib/pc_patch.c
+++ b/lib/pc_patch.c
@@ -324,7 +324,7 @@ pc_patch_from_wkb(const PCSCHEMA *s, uint8_t *wkb, size_t wkbsize)
 	* schema compression at this point. The schema compression is only
 	* forced at serialization time.
 	*/
-	pcid = wkb_get_pcid(wkb);
+	pcid = pc_wkb_get_pcid(wkb);
 	compression = wkb_get_compression(wkb);
 
 	if ( pcid != s->pcid )

--- a/lib/pc_util.c
+++ b/lib/pc_util.c
@@ -73,22 +73,21 @@ bytes_from_hexbytes(const char *hexbuf, size_t hexsize)
 	return buf;
 }
 
+static char *hexchr = "0123456789ABCDEF";
+
 char*
 hexbytes_from_bytes(const uint8_t *bytebuf, size_t bytesize)
 {
 	char *buf = pcalloc(2*bytesize + 1); /* 2 chars per byte + null terminator */
 	int i;
-	char *ptr = buf;
 
+	buf[2*bytesize] = '\0';
 	for ( i = 0; i < bytesize; i++ )
 	{
-		int incr = snprintf(ptr, 3, "%02X", bytebuf[i]);
-		if ( incr < 0 )
-		{
-			pcerror("write failure in hexbytes_from_bytes");
-			return NULL;
-		}
-		ptr += incr;
+		/* Top four bits to 0-F */
+		buf[2*i] = hexchr[bytebuf[i] >> 4];
+		/* Bottom four bits to 0-F */
+		buf[2*i+1] = hexchr[bytebuf[i] & 0x0F];
 	}
 
 	return buf;

--- a/lib/pc_util.c
+++ b/lib/pc_util.c
@@ -45,7 +45,7 @@ static uint8_t hex2char[256] =
 
 
 uint8_t*
-bytes_from_hexbytes(const char *hexbuf, size_t hexsize)
+pc_bytes_from_hexbytes(const char *hexbuf, size_t hexsize)
 {
 	uint8_t *buf = NULL;
 	register uint8_t h1, h2;
@@ -76,11 +76,10 @@ bytes_from_hexbytes(const char *hexbuf, size_t hexsize)
 static char *hexchr = "0123456789ABCDEF";
 
 char*
-hexbytes_from_bytes(const uint8_t *bytebuf, size_t bytesize)
+pc_hexbytes_from_bytes(const uint8_t *bytebuf, size_t bytesize)
 {
 	char *buf = pcalloc(2*bytesize + 1); /* 2 chars per byte + null terminator */
 	int i;
-
 	buf[2*bytesize] = '\0';
 	for ( i = 0; i < bytesize; i++ )
 	{
@@ -180,7 +179,7 @@ wkb_set_char(uint8_t *wkb, char c)
 }
 
 uint32_t
-wkb_get_pcid(const uint8_t *wkb)
+pc_wkb_get_pcid(const uint8_t *wkb)
 {
 	/* We expect the bytes to be in WKB format for PCPOINT/PCPATCH */
 	/* byte 0:   endian */

--- a/pgsql/pc_pgsql.c
+++ b/pgsql/pc_pgsql.c
@@ -148,9 +148,9 @@ pc_point_from_hexwkb(const char *hexwkb, size_t hexlen, FunctionCallInfoData *fc
 	PCPOINT *pt;
 	PCSCHEMA *schema;
 	uint32 pcid;
-	uint8 *wkb = bytes_from_hexbytes(hexwkb, hexlen);
+	uint8 *wkb = pc_bytes_from_hexbytes(hexwkb, hexlen);
 	size_t wkblen = hexlen/2;
-	pcid = wkb_get_pcid(wkb);
+	pcid = pc_wkb_get_pcid(wkb);
 	schema = pc_schema_from_pcid(pcid, fcinfo);
 	pt = pc_point_from_wkb(schema, wkb, wkblen);
 	pfree(wkb);
@@ -165,7 +165,7 @@ pc_point_to_hexwkb(const PCPOINT *pt)
 	char *hexwkb;
 
 	wkb = pc_point_to_wkb(pt, &wkb_size);
-	hexwkb = hexbytes_from_bytes(wkb, wkb_size);
+	hexwkb = pc_hexbytes_from_bytes(wkb, wkb_size);
 	pfree(wkb);
 	return hexwkb;
 }
@@ -181,9 +181,9 @@ pc_patch_from_hexwkb(const char *hexwkb, size_t hexlen, FunctionCallInfoData *fc
 	PCPATCH *patch;
 	PCSCHEMA *schema;
 	uint32 pcid;
-	uint8 *wkb = bytes_from_hexbytes(hexwkb, hexlen);
+	uint8 *wkb = pc_bytes_from_hexbytes(hexwkb, hexlen);
 	size_t wkblen = hexlen/2;
-	pcid = wkb_get_pcid(wkb);
+	pcid = pc_wkb_get_pcid(wkb);
 	if ( ! pcid )
 		elog(ERROR, "%s: pcid is zero", __func__);
 
@@ -204,7 +204,7 @@ pc_patch_to_hexwkb(const PCPATCH *patch)
 	char *hexwkb;
 
 	wkb = pc_patch_to_wkb(patch, &wkb_size);
-	hexwkb = hexbytes_from_bytes(wkb, wkb_size);
+	hexwkb = pc_hexbytes_from_bytes(wkb, wkb_size);
 	pfree(wkb);
 	return hexwkb;
 }


### PR DESCRIPTION
This PR does two things.

1. It greatly improves the performance of the `hexbytes_from_bytes` performance by avoiding calling `snprintf` for each byte. The implementation is now [similar](https://github.com/postgis/postgis/blob/svn-trunk/liblwgeom/lwout_wkb.c#L34-L58) to PostGIS.
1. It adds a `pc_` prefix to the `bytes_from_hexbytes`, `hexbytes_from_bytes` and `wkb_get_pcid` functions to avoid conflicts with other libraries like PostGIS.

Together, these two commits fix a major performance bug. See the [discussion](https://www.postgresql.org/message-id/flat/49f41956-f50b-9551-1943-6e12ed12fa29%40oslandia.com#49f41956-f50b-9551-1943-6e12ed12fa29@oslandia.com) on the pgsql-general mailing list and the [test case](https://github.com/elemoine/pgpc-perf) for more detail.