### PR TITLE
Remove "stat text default" argument

### DIFF
--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -275,15 +275,15 @@ CREATE OR REPLACE FUNCTION _PC_PatchStat(p pcpatch, statno int, attr text)
 	RETURNS numeric AS 'MODULE_PATHNAME', 'pcpatch_get_stat'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION PC_PatchMin(p pcpatch, attr text, stat text default 'min')
+CREATE OR REPLACE FUNCTION PC_PatchMin(p pcpatch, attr text)
 	RETURNS numeric AS $$ SELECT _PC_PatchStat(p, 0, attr) $$
 	LANGUAGE 'sql' IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION PC_PatchMax(p pcpatch, attr text, stat text default 'max')
+CREATE OR REPLACE FUNCTION PC_PatchMax(p pcpatch, attr text)
 	RETURNS numeric AS $$ SELECT _PC_PatchStat(p, 1, attr) $$
 	LANGUAGE 'sql' IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION PC_PatchAvg(p pcpatch, attr text, stat text default 'avg')
+CREATE OR REPLACE FUNCTION PC_PatchAvg(p pcpatch, attr text)
 	RETURNS numeric AS $$ SELECT _PC_PatchStat(p, 2, attr) $$
 	LANGUAGE 'sql' IMMUTABLE STRICT;
 


### PR DESCRIPTION
This removes the "stat text default" argument from the PC_PatchMin, PC_PatchMax and PC_PatchAvg functions. This argument is not used, and it causes performance issues as reported in https://github.com/pgpointcloud/pointcloud/issues/187.

With this, after upgrading, the PC_PatchMin, PC_PatchMax and PC_PatchAvg functions with the previous signature (with three arguments) will be preserved. DROP FUNCTION PC_PatchXXX(pcpatch, text, text) should be used to drop them.