### PR TITLE
Define inline for all systems, change for Windows to __inline

### DIFF
--- a/lib/sort_r/sort_r.h
+++ b/lib/sort_r/sort_r.h
@@ -24,16 +24,17 @@ void sort_r(void *base, size_t nel, size_t width,
 
 */
 
+#define _SORT_R_INLINE inline
+
 #if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
      defined __FreeBSD__ || defined __DragonFly__)
 #  define _SORT_R_BSD
-#  define _SORT_R_INLINE inline
 #elif (defined _GNU_SOURCE || defined __gnu_hurd__ || defined __GNU__ || \
        defined __linux__ || (defined __MINGW32__ && !defined __MINGW64_VERSION_MAJOR) || defined __GLIBC__)
 #  define _SORT_R_LINUX
-#  define _SORT_R_INLINE inline
 #elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
 #  define _SORT_R_WINDOWS
+#  undef _SORT_R_INLINE
 #  define _SORT_R_INLINE __inline
 #else
   /* Using our own recursive quicksort sort_r_simple() */


### PR DESCRIPTION
Adapted from upstream commit 1eb3da5945bfb753b56e389379795f1408b152e1

Fixes #186 