### PR TITLE
Use proper CMake idioms for libxml2 and zlib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,16 +89,12 @@ exec_program(${PG_CONFIG} ARGS --libs OUTPUT_VARIABLE PGSQL_LIBS)
 # libxml2
 
 find_package (LibXml2 REQUIRED)
-mark_as_advanced (CLEAR LIBXML2_INCLUDE_DIR)
-mark_as_advanced (CLEAR LIBXML2_LIBRARIES)
-include_directories (${LIBXML2_INCLUDE_DIR})
 
 
 #------------------------------------------------------------------------------
 # zlib
 
 find_package (ZLIB REQUIRED)
-include_directories (${ZLIB_INCLUDE_DIR})
 
 
 #------------------------------------------------------------------------------

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,6 +32,9 @@ set ( PC_HEADERS
         pc_config.h
         )
 
+include_directories(${LIBXML2_INCLUDE_DIRS})
+include_directories(${ZLIB_INCLUDE_DIRS})
+
 add_library (libpc-static STATIC ${PC_SOURCES} ${PC_HEADERS})
 add_library (liblazperf-static STATIC ${LAZPERF_SOURCES})
 
@@ -51,8 +54,13 @@ set_target_properties (liblazperf-static
     COMPILE_FLAGS "-fPIC -std=c++0x"
   )
 
-target_link_libraries (libpc-static xml2)
-target_link_libraries (libpc-static z)
+# TODO: remove ${LIBXML2_INCLUDE_DIR} eventually,
+# it's deprecated since CMake 3.7.2
+target_include_directories(libpc-static PUBLIC ${LIBXML2_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIRS})
+target_include_directories(libpc-static PUBLIC ${ZLIB_INCLUDE_DIRS})
+
+target_link_libraries (libpc-static ${LIBXML2_LIBRARIES})
+target_link_libraries (libpc-static ${ZLIB_LIBRARIES})
 target_link_libraries (libpc-static m)
 if (LIBGHT_FOUND)
   target_link_libraries (libpc-static ${LIBGHT_LIBRARY})


### PR DESCRIPTION
This makes pgpointcloud actually use information provided by find_package() for zlib and libxml2.

The mention of ${LIBXML2_INCLUDE_DIR} is left for compatibility since it was only included in CMake 3.7.2.