### PR TITLE
Better handling of versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Makefile
 */*/Makefile
 pgsql/pointcloud.control
 pgsql/pointcloud--*
+pgsql_postgis/pointcloud_postgis.control
+pgsql_postgis/pointcloud_postgis--*

--- a/configure.ac
+++ b/configure.ac
@@ -34,10 +34,17 @@ dnl AC_SUBST([LEX])
 dnl AC_SUBST([YACC])
 
 dnl ===========================================================================
-dnl Version Information imported from Version.config
+dnl Version Information imported from Version.config and Git
 dnl ===========================================================================
 
-POINTCLOUD_VERSION=`cat Version.config`
+AC_CHECK_PROG([GITCMD], [git —version], [yes], [no])
+AC_CHECK_FILE([.git], [DOTGITDIR=yes], [DOTGITDIR=no])
+if test "x${GITCMD}" = "xyes" -a "x${DOTGITDIR}" = "xyes"; then
+    GIT_COMMIT_HASH=" $(git rev-parse --short HEAD)"
+else
+    GIT_COMMIT_HASH=
+fi
+POINTCLOUD_VERSION="$(cat Version.config)$GIT_COMMIT_HASH"
 AC_SUBST([POINTCLOUD_VERSION])
 AC_DEFINE_UNQUOTED([POINTCLOUD_VERSION], ["$POINTCLOUD_VERSION"], [Pointcloud version])
 

--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -41,6 +41,10 @@ Datum pcpatch_size(PG_FUNCTION_ARGS);
 Datum pcpoint_size(PG_FUNCTION_ARGS);
 Datum pcpoint_pcid(PG_FUNCTION_ARGS);
 Datum pc_version(PG_FUNCTION_ARGS);
+Datum pc_pgsql_version(PG_FUNCTION_ARGS);
+Datum pc_libxml2_version(PG_FUNCTION_ARGS);
+Datum pc_libght_enable(PG_FUNCTION_ARGS);
+Datum pc_lazperf_enable(PG_FUNCTION_ARGS);
 
 /* Generic aggregation functions */
 Datum pointcloud_agg_transfn(PG_FUNCTION_ARGS);
@@ -858,6 +862,46 @@ Datum pc_version(PG_FUNCTION_ARGS)
 	snprintf(version, 64, "%s", POINTCLOUD_VERSION);
 	version_text = cstring_to_text(version);
 	PG_RETURN_TEXT_P(version_text);
+}
+
+PG_FUNCTION_INFO_V1(pc_pgsql_version);
+Datum pc_pgsql_version(PG_FUNCTION_ARGS)
+{
+	text *version_text;
+	char version[12];
+	snprintf(version, 12, "%d", PGSQL_VERSION);
+	version_text = cstring_to_text(version);
+	PG_RETURN_TEXT_P(version_text);
+}
+
+PG_FUNCTION_INFO_V1(pc_libxml2_version);
+Datum pc_libxml2_version(PG_FUNCTION_ARGS)
+{
+	text *version_text;
+	char version[64];
+	snprintf(version, 64, "%s", LIBXML2_VERSION);
+	version_text = cstring_to_text(version);
+	PG_RETURN_TEXT_P(version_text);
+}
+
+PG_FUNCTION_INFO_V1(pc_libght_enabled);
+Datum pc_libght_enabled(PG_FUNCTION_ARGS)
+{
+#ifdef HAVE_LIBGHT
+	PG_RETURN_BOOL(TRUE);
+#else
+	PG_RETURN_BOOL(FALSE);
+#endif
+}
+
+PG_FUNCTION_INFO_V1(pc_lazperf_enabled);
+Datum pc_lazperf_enabled(PG_FUNCTION_ARGS)
+{
+#ifdef HAVE_LAZPERF
+	PG_RETURN_BOOL(TRUE);
+#else
+	PG_RETURN_BOOL(FALSE);
+#endif
 }
 
 /**

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -56,6 +56,26 @@ CREATE OR REPLACE FUNCTION pc_lib_version()
 	RETURNS text AS 'MODULE_PATHNAME', 'pc_version'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
+-- Return the pgsql version number
+CREATE OR REPLACE FUNCTION pc_pgsql_version()
+	RETURNS text AS 'MODULE_PATHNAME', 'pc_pgsql_version'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
+-- Return the libxml2 version number
+CREATE OR REPLACE FUNCTION pc_libxml2_version()
+	RETURNS text AS 'MODULE_PATHNAME', 'pc_libxml2_version'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
+-- Return whether libght is enabled
+CREATE OR REPLACE FUNCTION pc_libght_enabled()
+	RETURNS boolean AS 'MODULE_PATHNAME', 'pc_libght_enabled'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
+-- Return whether lazperf is enabled
+CREATE OR REPLACE FUNCTION pc_lazperf_enabled()
+	RETURNS boolean AS 'MODULE_PATHNAME', 'pc_lazperf_enabled'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
 -- Return the extension version number and check sanity
 CREATE OR REPLACE FUNCTION pc_version()
 	RETURNS text AS
@@ -71,6 +91,27 @@ BEGIN
 			libver, scrver;
 	END IF;
 	RETURN libver;
+END;
+$$
+LANGUAGE 'plpgsql' IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION pc_full_version()
+	RETURNS text AS
+$$
+DECLARE
+	pcver TEXT;
+	pgsqlver TEXT;
+	libxml2ver TEXT;
+	libghtenabled BOOLEAN;
+	lazperfenabled BOOLEAN;
+BEGIN
+	pcver := pc_version();
+	pgsqlver := pc_pgsql_version();
+	libxml2ver := pc_libxml2_version();
+	libghtenabled := pc_libght_enabled();
+	lazperfenabled := pc_lazperf_enabled();
+	RETURN 'POINTCLOUD="' || pcver || '" PGSQL="' || pgsqlver || '" LIBXML2="' || libxml2ver ||
+		'" LIBGHT enabled=' || libghtenabled || ' LAZPERF enabled=' || lazperfenabled;
 END;
 $$
 LANGUAGE 'plpgsql' IMMUTABLE STRICT;

--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -76,41 +76,61 @@ CREATE OR REPLACE FUNCTION pc_lazperf_enabled()
 	RETURNS boolean AS 'MODULE_PATHNAME', 'pc_lazperf_enabled'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
--- Return the extension version number and check sanity
+-- Return the extension version number with the commit hash trimmed, and check sanity
+CREATE OR REPLACE FUNCTION _pc_version_no_commit(libver text, scrver text)
+	RETURNS text AS
+$$
+DECLARE
+	libver_no_commit TEXT;
+BEGIN
+	libver_no_commit := split_part(libver, ' ', 1);
+	IF scrver != libver_no_commit THEN
+		RAISE WARNING 'Library (%) and script (%) version mismatch',
+			libver_no_commit, scrver;
+	END IF;
+	RETURN libver_no_commit;
+END;
+$$
+LANGUAGE 'plpgsql' IMMUTABLE STRICT;
+
+-- Return the extension version number, and check sanity
 CREATE OR REPLACE FUNCTION pc_version()
 	RETURNS text AS
 $$
 DECLARE
 	libver TEXT;
 	scrver TEXT;
+	version TEXT;
 BEGIN
-	scrver := pc_script_version();
 	libver := pc_lib_version();
-	IF scrver != libver THEN
-		RAISE WARNING 'Library (%) and script (%) version mismatch',
-			libver, scrver;
-	END IF;
-	RETURN libver;
+	scrver := pc_script_version();
+	version := _pc_version_no_commit(libver, scrver);
+	RETURN version;
 END;
 $$
 LANGUAGE 'plpgsql' IMMUTABLE STRICT;
 
+-- Return the full version string
 CREATE OR REPLACE FUNCTION pc_full_version()
 	RETURNS text AS
 $$
 DECLARE
 	pcver TEXT;
+	pclibver TEXT;
+	pcscrver TEXT;
 	pgsqlver TEXT;
 	libxml2ver TEXT;
 	libghtenabled BOOLEAN;
 	lazperfenabled BOOLEAN;
 BEGIN
-	pcver := pc_version();
+	pclibver := pc_lib_version();
+	pcscrver := pc_script_version();
+	pcver := _pc_version_no_commit(pclibver, pcscrver);
 	pgsqlver := pc_pgsql_version();
 	libxml2ver := pc_libxml2_version();
 	libghtenabled := pc_libght_enabled();
 	lazperfenabled := pc_lazperf_enabled();
-	RETURN 'POINTCLOUD="' || pcver || '" PGSQL="' || pgsqlver || '" LIBXML2="' || libxml2ver ||
+	RETURN 'POINTCLOUD="' || pclibver || '" PGSQL="' || pgsqlver || '" LIBXML2="' || libxml2ver ||
 		'" LIBGHT enabled=' || libghtenabled || ' LAZPERF enabled=' || lazperfenabled;
 END;
 $$

--- a/pgsql_postgis/Makefile
+++ b/pgsql_postgis/Makefile
@@ -4,8 +4,12 @@ include ../config.mk
 
 #MODULE_big = pointcloud_postgis
 #OBJS =
+SED = sed
 EXTENSION = pointcloud_postgis
-DATA = $(EXTENSION)--1.0.sql
+EXTVERSION=$(shell cat ../Version.config)
+DATA_built = \
+  $(EXTENSION).control \
+  $(EXTENSION)--$(EXTVERSION).sql
 
 #REGRESS = pointcloud
 
@@ -15,3 +19,9 @@ DATA = $(EXTENSION)--1.0.sql
 
 # We are going to use PGXS for sure
 include $(PGXS)
+
+$(EXTENSION).control: $(EXTENSION).control.in Makefile
+	$(SED) -e 's/@POINTCLOUD_VERSION@/$(EXTVERSION)/' $< > $@
+
+$(EXTENSION)--$(EXTVERSION).sql: $(EXTENSION).sql.in Makefile
+	$(SED) -e 's/@POINTCLOUD_VERSION@/$(EXTVERSION)/' $< > $@

--- a/pgsql_postgis/pointcloud_postgis.control.in
+++ b/pgsql_postgis/pointcloud_postgis.control.in
@@ -1,6 +1,6 @@
 # pointcloud postgis integration extension
 comment = 'integration for pointcloud LIDAR data and PostGIS geometry data'
-default_version = '1.0'
+default_version = '@POINTCLOUD_VERSION@'
 relocatable = true
 superuser = false
 requires = 'postgis, pointcloud'

--- a/pgsql_postgis/pointcloud_postgis.sql.in
+++ b/pgsql_postgis/pointcloud_postgis.sql.in
@@ -72,3 +72,10 @@ CREATE OR REPLACE FUNCTION PC_BoundingDiagonalGeometry(pcpatch)
 		SELECT ST_GeomFromEWKB(PC_BoundingDiagonalAsBinary($1))
 	$$
 	LANGUAGE 'sql';
+
+-----------------------------------------------------------------------------
+-- Function returning the version number
+--
+CREATE OR REPLACE FUNCTION PC_PostGIS_Version()
+	RETURNS text AS $$ SELECT '@POINTCLOUD_VERSION@'::text $$
+	LANGUAGE 'sql' IMMUTABLE STRICT;


### PR DESCRIPTION
This PR does two things:

- make the versions of the pointcloud and pointcloud_postgis extensions the same
- add a pc_full_version function that includes more information than just the pointcloud version

This is what pc_full_version returns:

```
# select pc_full_version();
                                     pc_full_version
------------------------------------------------------------------------------------------
 POINTCLOUD="1.1.0" PGSQL="96" LIBXML2="2.9.4" LIBGHT enabled=false LAZPERF enabled=false
(1 row)
```

@robe2 is that what you had in mind?