### PR TITLE
Trying bytea->pcpoint conversion

### DIFF
--- a/pgsql/pointcloud.sql.in
+++ b/pgsql/pointcloud.sql.in
@@ -186,6 +186,16 @@ CREATE OR REPLACE FUNCTION pcpoint_in(cstring)
 	RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpoint_in'
 	LANGUAGE 'c' IMMUTABLE STRICT;
 
+
+CREATE OR REPLACE FUNCTION pcpoint_in(internal)
+	RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpoint_in_bytea'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
+
+CREATE OR REPLACE FUNCTION pcpoint_in(bytea)
+	RETURNS pcpoint AS 'MODULE_PATHNAME', 'pcpoint_in_bytea'
+	LANGUAGE 'c' IMMUTABLE STRICT;
+
 CREATE OR REPLACE FUNCTION pcpoint_out(pcpoint)
 	RETURNS cstring AS 'MODULE_PATHNAME', 'pcpoint_out'
 	LANGUAGE 'c' IMMUTABLE STRICT;
@@ -224,6 +234,9 @@ CREATE OR REPLACE FUNCTION PC_AsText(p pcpoint)
 CREATE OR REPLACE FUNCTION PC_AsBinary(p pcpoint)
 	RETURNS bytea AS 'MODULE_PATHNAME', 'pcpoint_as_bytea'
 	LANGUAGE 'c' IMMUTABLE STRICT;
+
+CREATE CAST (bytea as pcpoint) WITH FUNCTION pcpoint_in(bytea) AS ASSIGNMENT;
+
 
 -------------------------------------------------------------------
 --  PCPATCH


### PR DESCRIPTION
The following patch enables code like:

```
select (decode('0104000000010001', 'hex'))::pcpoint;
```

Feedback requested.

I was hoping to take advantage of new bytea->pcpoint function as the `receive_function`, but I'm not quite sure how that works or if I did it right.  Any tips suggested. :)