### PR TITLE
Adds missing description in AC_DEFINE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ if test "x$CUNITDIR" != "x"; then
 fi
 
 if test "$FOUND_CUNIT" = "YES"; then
-  AC_DEFINE([HAVE_CUNIT])
+  AC_DEFINE([HAVE_CUNIT], [1], [Have CUnit])
   CUNIT_STATUS="enabled"
   if test $CUNITDIR; then
     CUNIT_STATUS="$CUNITDIR"
@@ -319,7 +319,7 @@ elif test "x$GHTDIR" != "xno"; then
 fi
 
 if test "x$FOUND_GHT_H" = "xYES" -a "x$FOUND_GHT_LIB" = "xYES"; then
-  AC_DEFINE([HAVE_LIBGHT])
+  AC_DEFINE([HAVE_LIBGHT], [1], [Have libght])
   GHT_STATUS="enabled"
   if test $GHTDIR; then
     GHT_STATUS="$GHTDIR"
@@ -368,7 +368,7 @@ elif test "x$LAZPERFDIR" != "xno"; then
 fi
 
 if test "x$FOUND_LAZPERF" = "xYES"; then
-  AC_DEFINE([HAVE_LAZPERF])
+  AC_DEFINE([HAVE_LAZPERF], [1], [Have LAZ perf])
   LAZPERF_STATUS="enabled"
   if test $LAZPERFDIR; then
     LAZPERF_STATUS="$LAZPERFDIR/include/laz-perf"
@@ -384,7 +384,7 @@ dnl ===========================================================================
 dnl Figure out where this script is running
 
 PROJECT_SOURCE_DIR="$( cd "$( dirname $0 )" && pwd )"
-AC_DEFINE_UNQUOTED([PROJECT_SOURCE_DIR],"$PROJECT_SOURCE_DIR")
+AC_DEFINE_UNQUOTED([PROJECT_SOURCE_DIR], ["$PROJECT_SOURCE_DIR"], [Project source dir])
 
 
 dnl ===========================================================================


### PR DESCRIPTION
Some AC_DEFINE returns warnings:

> 
> autoheader-2.69: warning: missing template: HAVE_CUNIT
> autoheader-2.69: Use AC_DEFINE([HAVE_CUNIT], [], [Description])
> autoheader-2.69: warning: missing template: HAVE_LAZPERF
> autoheader-2.69: warning: missing template: HAVE_LIBGHT
> autoheader-2.69: warning: missing template: PROJECT_SOURCE_DIR
> autoreconf-2.69: /usr/local/bin/autoheader-2.69 failed with exit status: 1
> *** Error code 1

Needed to package pointcloud 1.1.0 in FreeBSD.

