### PR TITLE
Fix memcpy size in pc_patch_wkb_set_int32

### DIFF
--- a/pgsql/pc_pgsql.c
+++ b/pgsql/pc_pgsql.c
@@ -860,7 +860,7 @@ pc_patch_wkb_set_double(uint8_t *wkb, double d)
 static uint8_t *
 pc_patch_wkb_set_int32(uint8_t *wkb, uint32_t i)
 {
-	memcpy(wkb, &i, 8);
+	memcpy(wkb, &i, 4);
 	wkb += 4;
 	return wkb;
 }


### PR DESCRIPTION
Using -Wall and -O2 gcc 8.2.0 warns us about memcpy's that are out-of-bounds.

```
In file included from /usr/include/string.h:494,
                 from ../lib/pc_api.h:18,
                 from pc_pgsql.h:12,
                 from pc_pgsql.c:14:
In function ‘memcpy’,
    inlined from ‘pc_patch_wkb_set_int32’ at pc_pgsql.c:863:2,
    inlined from ‘pc_patch_to_geometry_wkb_envelope’ at pc_pgsql.c:918:8:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ forming offset [5, 8] is out of the bounds [0, 4] of object ‘i’ with type ‘uint32_t’ {aka ‘unsigned int’} [-Warray-bounds]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

gcc is correct, there is a bug in pc_patch_wkb_set_int32. We should copy 4 bytes instead of 8 bytes.