### PR TITLE
Fix boolean case errors when compiling againt pg11

### DIFF
--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -879,9 +879,9 @@ Datum pcpatch_intersects(PG_FUNCTION_ARGS)
 
 	if ( pc_bounds_intersects(&(serpa1->bounds), &(serpa2->bounds)) )
 	{
-		PG_RETURN_BOOL(TRUE);
+		PG_RETURN_BOOL(true);
 	}
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 }
 
 PG_FUNCTION_INFO_V1(pcpatch_size);
@@ -939,9 +939,9 @@ PG_FUNCTION_INFO_V1(pc_lazperf_enabled);
 Datum pc_lazperf_enabled(PG_FUNCTION_ARGS)
 {
 #ifdef HAVE_LAZPERF
-	PG_RETURN_BOOL(TRUE);
+	PG_RETURN_BOOL(true);
 #else
-	PG_RETURN_BOOL(FALSE);
+	PG_RETURN_BOOL(false);
 #endif
 }
 

--- a/pgsql/pc_inout.c
+++ b/pgsql/pc_inout.c
@@ -171,7 +171,7 @@ Datum pcschema_is_valid(PG_FUNCTION_ARGS)
 
 	if ( !schema )
 	{
-		PG_RETURN_BOOL(FALSE);
+		PG_RETURN_BOOL(false);
 	}
 
 	valid = pc_schema_is_valid(schema);


### PR DESCRIPTION
This PR fixes #236 

The following commit in PostgreSQL [2eb4a831e5fb5d8fc17e13aea56e04af3efe27b4](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=2eb4a831e5fb5d8fc17e13aea56e04af3efe27b4) changed from uppercase to lowercase.

This PR changes the case of boolean values where it is needed to be able to compile.