### PR TITLE
Don't overwrite CXXFLAGS from environment

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -1,6 +1,6 @@
 CC = @CC@
 CFLAGS = @CFLAGS@
-CXXFLAGS = -fPIC -std=c++0x
+CXXFLAGS += -fPIC -std=c++0x
 SQLPP = @SQLPP@
 
 XML2_CPPFLAGS = @XML2_CPPFLAGS@


### PR DESCRIPTION
Spotted by Debian's build log hardening checker (blhc).