### PR TITLE
Add Dockerfile with PostgreSQL 12 and PostGIS 3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,38 @@
+FROM postgres:12
+MAINTAINER Paul Blottiere <blottiere.paul@gmail.com>
+
+ENV POSTGRES_VERSION 12
+ENV POSTGIS_VERSION 3
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        postgis \
+        postgresql-${POSTGRES_VERSION}-postgis-${POSTGIS_VERSION} \
+        postgresql-${POSTGRES_VERSION}-postgis-${POSTGIS_VERSION}-scripts
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        build-essential \
+        autoconf \
+        automake \
+        zlib1g-dev \
+        postgresql-server-dev-all \
+        libxml2-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && git clone https://github.com/pgpointcloud/pointcloud \
+    && cd pointcloud \
+    && ./autogen.sh \
+    && ./configure --with-pgconfig=/usr/lib/postgresql/${POSTGRES_VERSION}/bin/pg_config CFLAGS="-Wall -Werror -O2 -g" \
+    && make \
+    && make install \
+    && apt-get purge -y --auto-remove \
+        git \
+        ca-certificates \
+        build-essential \
+        autoconf \
+        automake \
+        zlib1g-dev \
+        postgresql-server-dev-all \
+        libxml2-dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,14 +17,22 @@ RUN apt-get update \
         build-essential \
         autoconf \
         automake \
+        cmake \
         zlib1g-dev \
         postgresql-server-dev-all \
         libxml2-dev \
     && rm -rf /var/lib/apt/lists/* \
+    && git clone https://github.com/verma/laz-perf.git \
+    && cd laz-perf \
+    && cmake . \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -r laz-perf \
     && git clone https://github.com/pgpointcloud/pointcloud \
     && cd pointcloud \
     && ./autogen.sh \
-    && ./configure --with-pgconfig=/usr/lib/postgresql/${POSTGRES_VERSION}/bin/pg_config CFLAGS="-Wall -Werror -O2 -g" \
+    && ./configure --with-lazperf=/usr/local --with-pgconfig=/usr/lib/postgresql/${POSTGRES_VERSION}/bin/pg_config CFLAGS="-Wall -Werror -O2 -g" \
     && make \
     && make install \
     && apt-get purge -y --auto-remove \
@@ -33,6 +41,7 @@ RUN apt-get update \
         build-essential \
         autoconf \
         automake \
+        cmake \
         zlib1g-dev \
         postgresql-server-dev-all \
         libxml2-dev


### PR DESCRIPTION
Supersede https://github.com/pgpointcloud/pointcloud/pull/182.

Add a Dockerfile based on [official PostgreSQL 12 image](https://hub.docker.com/_/postgres/) with PostGIS 3 and lazperf support.