### PR TITLE
Ignore minor version for postgresql >= 9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,11 @@ dnl the final version. This is to guard against user error...
 PGSQL_FULL_VERSION=`$PG_CONFIG --version`
 PGSQL_MAJOR_VERSION=`echo $PGSQL_FULL_VERSION | sed 's/[[^0-9]]*\([[0-9]]*\).*/\1/'`
 PGSQL_MINOR_VERSION=`echo $PGSQL_FULL_VERSION | sed 's/[[^0-9]]*\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
+
+if test "$PGSQL_MAJOR_VERSION" -ge 9; then
+	PGSQL_MINOR_VERSION=0
+fi
+
 PGSQL_VERSION="$PGSQL_MAJOR_VERSION$PGSQL_MINOR_VERSION"
 
 AC_SUBST([PGSQL_MAJOR_VERSION])


### PR DESCRIPTION
Fixes https://github.com/pgpointcloud/pointcloud/issues/268 

The minor version of PostgreSQL is wrongly detected in some cases. For example on PostgreSQL 13 beta1 release:

``` bash
$ pg_config --version
PostgreSQL 13beta1 (Debian 13~beta1-1.pgdg100+1)
$ ./configure
...

  PointCloud is now configured for

 -------------- Compiler Info -------------
  C compiler:           gcc -g -O2
  SQL preprocessor:     /usr/bin/cpp -traditional-cpp -w -P

 -------------- Dependencies --------------
  PostgreSQL config:    /usr/bin/pg_config
  PostgreSQL version:   PostgreSQL 13beta1 (Debian 13~beta1-1.pgdg100+1) (13PostgreSQL 13beta1 (Debian 13~beta1)
  Libxml2 config:       /usr/bin/xml2-config
  Libxml2 version:      2.9.4
  LazPerf status:       disabled
  CUnit status:         disabled
```

In this case the version is detected as `13PostgreSQL 13beta1 (Debian 13~beta1`. 

By taking a look on the `configure.ac` file from PostGIS, I noticed that the minor version is basically ignored for all PostgreSQL release >= 9:

``` bash
if test "$PGSQL_MAJOR_VERSION" -ge 9; then
	PGSQL_MINOR_VERSION=0
fi
```

So I'm introducing the same mechanism here.