### PR TITLE
Fix for PG16 stringToQualifiedNameList

### DIFF
--- a/pgsql/pc_pgsql.c
+++ b/pgsql/pc_pgsql.c
@@ -44,7 +44,11 @@ static PC_CONSTANTS *pc_constants_cache = NULL;
 static Oid pointcloud_get_full_version_schema()
 {
   const char *proname = "pointcloud_full_version";
+#if PGSQL_VERSION < 160
   List *names = stringToQualifiedNameList(proname);
+#else
+  List *names = stringToQualifiedNameList(proname, NULL);
+#endif
 #if PGSQL_VERSION < 140
   FuncCandidateList clist =
       FuncnameGetCandidates(names, -1, NIL, false, false, false);


### PR DESCRIPTION
Closes #338

This fixes the stringToQualifiedNameList

Technically that NULL should be NIL, but then I'd need to drag in another include to use NIL

Sadly the tests still don't all pass.  The pointcloud test is failing on my system:

```
# using postmaster on localhost, port 5453
not ok 1     - pointcloud                                326 ms
ok 2         - pointcloud_columns                        116 ms
ok 3         - schema                                     54 ms
1..3
```

At a glance the issue is a harmless one.

For example for the test:

```
-- test PC_SetPCId
-- from pcid 1 to 1 (same dimensions, same positions, same compressions)
-- pcid 1: (X,Y,Z,I), scaled, uncompressed
SELECT
  PC_AsText(PC_SetPCId(p, 1)) t, PC_Summary(PC_SetPCId(p, 1))::json->'compr' c
FROM ( SELECT PC_Patch(PC_MakePoint(1, ARRAY[-1,0,4862413,1])) p ) foo;
```

The expected result is:
```
                    t                    |   c    
-----------------------------------------+--------
 {"pcid":1,"pts":[[-1,0,4.86241e+06,1]]} | "none"
```

But I'm getting below on my mingw64 gcc 8.1, PG16 beta2

```
                    t                     |   c    
------------------------------------------+--------
 {"pcid":1,"pts":[[-1,0,4.86241e+006,1]]} | "none"

```

Thought this might be a mingw64 issue, I'm going to add test in a separate pull request to check

