### PR TITLE
Honor '--without-cunit' configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ if test "x$CUNITDIR" != "x"; then
   CPPFLAGS="${CPPFLAGS_SAVE}"
 fi
 
-if test "$FOUND_CUNIT" = "YES"; then
+if test "$FOUND_CUNIT" = "YES" && test x${with_cunit} != "xno"; then
   AC_DEFINE([HAVE_CUNIT], [1], [Have CUnit])
   CUNIT_STATUS="enabled"
   if test $CUNITDIR; then


### PR DESCRIPTION
Addresses a CUnit configuration bug.

Configuring with CUnit present on system, but with `--without-cunit` flag leads to non-sensical compiling flags:

```
CUNIT_CPPFLAGS='-Ino/include'
CUNIT_LDFLAGS='-Lno/lib -lcunit'
```
