### PR TITLE
Explicitly set LazPerf version to v1.5 to add support in the Docker i…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Paul Blottiere <blottiere.paul@gmail.com>
 
 ENV POSTGRES_VERSION 14
 ENV POSTGIS_VERSION 3
+ENV LAZPERF_VERSION 1.5.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -22,9 +23,10 @@ RUN apt-get update \
         postgresql-server-dev-all \
         libxml2-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && git clone https://github.com/verma/laz-perf.git \
+    && git clone https://github.com/hobuinc/laz-perf.git \
     && cd laz-perf \
-    && cmake . \
+    && git checkout ${LAZPERF_VERSION} \
+    && cmake -DWITH_TESTS=FALSE . \
     && make \
     && make install \
     && cd .. \

--- a/tools/build_install.sh
+++ b/tools/build_install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -f config.mk ]]; then
+if [ -f config.mk ]; then
     make clean maintainer-clean
 fi
 

--- a/tools/install_lazperf.sh
+++ b/tools/install_lazperf.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -ex
-git clone https://github.com/verma/laz-perf.git
-cd laz-perf;  cmake .; make; sudo make install
+git clone https://github.com/hobuinc/laz-perf.git
+cd laz-perf; git checkout 1.5.0; cmake -DWITH_TESTS=FALSE .; make; sudo make install


### PR DESCRIPTION
…mage and fix the CI (some work is needed to upgrade to a newer version)

Fixes #https://github.com/pgpointcloud/pointcloud/issues/355