### PR TITLE
Fix build against PostgreSQL 19

### DIFF
--- a/pgsql/pc_access.c
+++ b/pgsql/pc_access.c
@@ -126,7 +126,7 @@ Datum pcpoint_get_values(PG_FUNCTION_ARGS)
   PG_RETURN_ARRAYTYPE_P(result);
 }
 
-static inline bool array_get_isnull(const bits8 *nullbitmap, int offset)
+static inline bool array_get_isnull(const uint8 *nullbitmap, int offset)
 {
   if (nullbitmap == NULL)
   {
@@ -147,7 +147,7 @@ pcpatch_from_point_array(ArrayType *array, FunctionCallInfo fcinfo)
 #endif
 {
   int nelems;
-  bits8 *bitmap;
+  uint8 *bitmap;
   size_t offset = 0;
   int i;
   uint32 pcid = 0;
@@ -222,7 +222,7 @@ pcpatch_from_patch_array(ArrayType *array, FunctionCallInfo fcinfo)
 #endif
 {
   int nelems;
-  bits8 *bitmap;
+  uint8 *bitmap;
   size_t offset = 0;
   int i;
   uint32 pcid = 0;
@@ -1127,7 +1127,7 @@ const char **array_to_cstring_array(ArrayType *array, int *size)
   int i, j, offset = 0;
   int nelems = ArrayGetNItems(ARR_NDIM(array), ARR_DIMS(array));
   const char **cstring = nelems ? pcalloc(nelems * sizeof(char *)) : NULL;
-  bits8 *bitmap = ARR_NULLBITMAP(array);
+  uint8 *bitmap = ARR_NULLBITMAP(array);
   for (i = j = 0; i < nelems; ++i)
   {
     text *array_text;

--- a/pgsql/pc_pgsql.c
+++ b/pgsql/pc_pgsql.c
@@ -52,9 +52,14 @@ static Oid pointcloud_get_full_version_schema()
 #if PGSQL_VERSION < 140
   FuncCandidateList clist =
       FuncnameGetCandidates(names, -1, NIL, false, false, false);
-#else
+#elif PGSQL_VERSION < 190
   FuncCandidateList clist =
       FuncnameGetCandidates(names, -1, NIL, false, false, false, false);
+#else
+  int fgc_flags;
+  FuncCandidateList clist =
+      FuncnameGetCandidates(names, -1, NIL, false, false, false, false,
+                            &fgc_flags);
 #endif
   if (!clist)
     return InvalidOid;


### PR DESCRIPTION
 1. pc_access.c PG19 removed the `bits8` typedef (utils/array.h now uses `uint8` directly, e.g. ARR_NULLBITMAP() returns uint8*). Replace all uses of `bits8` with `uint8` (array_get_isnull(), pcpatch_from_point_array(), pcpatch_from_patch_array(), array_to_cstring_array()).

 2. pc_pgsql.c PG19 added an `int *fgc_flags` output parameter to FuncnameGetCandidates() (8 args instead of 7), used to report why a lookup failed. Add a new `#elif PGSQL_VERSION < 190` branch that keeps the existing PG14-PG18 (7-arg) call, and a PG19+ branch that passes a local `int fgc_flags` to satisfy the new signature. The flags aren't otherwise consumed since this call only wants the OID of a uniquely-named function.

Per https://github.com/pgdg-packaging/pgdg-rpms/issues/213